### PR TITLE
Add verbose_eval option.

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -14,7 +14,7 @@ class NGBoost(object):
     def __init__(self, Dist=Normal, Score=MLE(),
                  Base=default_tree_learner, natural_gradient=False,
                  n_estimators=500, learning_rate=0.01, minibatch_frac=1.0,
-                 verbose=True, verbose_eval=1, tol=1e-4):
+                 verbose=True, verbose_eval=100, tol=1e-4):
         self.Dist = Dist
         self.Score = Score
         self.Base = Base

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -14,7 +14,7 @@ class NGBoost(object):
     def __init__(self, Dist=Normal, Score=MLE(),
                  Base=default_tree_learner, natural_gradient=False,
                  n_estimators=500, learning_rate=0.01, minibatch_frac=1.0,
-                 verbose=True, tol=1e-4):
+                 verbose=True, verbose_eval=1, tol=1e-4):
         self.Dist = Dist
         self.Score = Score
         self.Base = Base
@@ -23,6 +23,7 @@ class NGBoost(object):
         self.learning_rate = learning_rate
         self.minibatch_frac = minibatch_frac
         self.verbose = verbose
+        self.verbose_eval = verbose_eval
         self.init_params = None
         self.base_models = []
         self.scalings = []
@@ -102,7 +103,7 @@ class NGBoost(object):
                         print(f"== Quitting at iteration / VAL {itr} (val_loss={val_loss:.4f})")
                     break
 
-            if self.verbose:
+            if self.verbose and int(self.verbose_eval) > 0 and itr % int(self.verbose_eval) == 0:
                 grad_norm = np.linalg.norm(grads, axis=1).mean() * scale
                 print(f"[iter {itr}] loss={loss:.4f} val_loss={val_loss:.4f} scale={scale:.4f} "
                       f"norm={grad_norm:.4f}")


### PR DESCRIPTION
Add verbose_eval option to NGBoost to reduce loss history on a log like LightGBM etc.

Usage:
If ` verbose_eval=10` then loss history is shown at every 10 iteration.
```
ngb = NGBoost(Base=default_tree_learner, Dist=Normal,
              Score=MLE(), natural_gradient=True, verbose=True, 
              verbose_eval=10)
```