### PR TITLE
Add pred_dist_pdf method for easy to use pdf distribution data.

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -130,6 +130,11 @@ class NGBoost(object):
         dist = self.Dist(params.T)
         return dist
 
+    def pred_dist_pdf(self, X, y_range, max_iter=None):
+        dist_obj = self.pred_dist(X, max_iter)
+        dist_obj_pdf = [dist_obj.pdf(y) for y in y_range]
+        return [[float(dist_obj_pdf[i][j]) for i in range(len(y_range))] for j in range(len(X))]
+
     def predict(self, X):
         dist = self.pred_dist(X)
         return list(dist.loc.flatten())


### PR DESCRIPTION
Adding `pred_dist_pdf()` method for NGBoost class in order to get pdf distribution of each X data with given x_range data. In detail merit of this function, please see the following notebook. It is easy to get distribution data for NGBoost users.

Usage example:
https://nbviewer.jupyter.org/github/matsuken92/ngboost/blob/notebooks/examples/notebooks/pred_dist_pdf_demo.ipynb