### PR TITLE
Add feature importance function on NGBoost

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -28,6 +28,7 @@ class NGBoost(object):
         self.base_models = []
         self.scalings = []
         self.tol = tol
+        self.best_iteration = -1
 
     def pred_param(self, X, max_iter=None):
         m, n = X.shape
@@ -101,6 +102,7 @@ class NGBoost(object):
                    np.mean(np.array(val_loss_list[-10:-5])):
                     if self.verbose:
                         print(f"== Quitting at iteration / VAL {itr} (val_loss={val_loss:.4f})")
+                        self.best_iteration = itr
                     break
 
             if self.verbose and int(self.verbose_eval) > 0 and itr % int(self.verbose_eval) == 0:

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -126,6 +126,10 @@ class NGBoost(object):
         self.init_params = self.Dist.fit(T)
         return
 
+    def feature_importance(self):
+        importance_base = np.array([[m[i].feature_importances_ for m in self.base_models[:self.best_iteration]]
+                                    for i in range(self.Dist.n_params)])
+        return importance_base.sum(axis=1).transpose()
 
     def pred_dist(self, X, max_iter=None):
         params = np.asarray(self.pred_param(X, max_iter))


### PR DESCRIPTION
Adding feature_importance() method for NGBoost class to check feature importance as sum of the each decision tree.

Usage example:
```
data = load_boston()
X, y = data.data, data.target
X_train, X_valid, y_train, y_valid = train_test_split(X, y, test_size=0.2)
ngb = NGBoost(Base=default_tree_learner, Dist=Normal, #Normal, LogNormal
              Score=MLE(), natural_gradient=True, verbose=True,)
ngb.fit(X_train, y_train, X_val=X_valid, Y_val=y_valid)
feature_importance = ngb.feature_importance()
feature_importance_df = pd.DataFrame(feature_importance, index=data.feature_names)
```

https://nbviewer.jupyter.org/github/matsuken92/ngboost/blob/notebooks/examples/notebooks/feature_importance_demo.ipynb

or 

https://github.com/matsuken92/ngboost/blob/notebooks/examples/notebooks/feature_importance_demo.ipynb