### PR TITLE
Import NGBoost class  into __init__

### DIFF
--- a/ngboost/__init__.py
+++ b/ngboost/__init__.py
@@ -1,0 +1,1 @@
+from .ngboost import NGBoost


### PR DESCRIPTION
Proposing that we have NGBoost importable from top-level module.

Doing so will improve the import API, such that it now reads as follows:

```python
from ngboost import NGBoost
```

rather than

```python
from ngboost.ngboost import NGBoost
```

(The latter can sometimes be confusing for not-so-seasoned Python programmers.