### PR TITLE
WIP: early_stopping_rounds added

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -109,9 +109,11 @@ class NGBoost(BaseEstimator):
                 val_loss = val_loss_monitor(self.Dist(val_params.T), Y_val)
                 val_loss_list += [val_loss]
                 if self.early_stopping_rounds is not None:
-                    if np.min(np.array(val_loss_list)) < np.min(np.array(val_loss_list[-self.early_stopping_rounds:])):
-                        best_itr = np.argmin(np.array(val_loss_list))
-                        best_val_loss = np.min(np.array(val_loss_list))
+                    best_val_loss = np.min(np.array(val_loss_list))
+                    best_itr = np.argmin(np.array(val_loss_list))
+                    self.best_val_loss = best_val_loss
+                    self.best_itr = best_itr
+                    if best_val_loss < np.min(np.array(val_loss_list[-self.early_stopping_rounds:])):
                         if self.verbose:
                             print(f"== Early stopping achieved.")
                             print(f"== Best iteration / VAL {best_itr} (val_loss={best_val_loss:.4f})")


### PR DESCRIPTION
Implemented basic logic for early stopping. 

If the model parameter `early_stopping_rounds` is set, the training stops after such number of iterations pass without loss improvement. 
If `early_stopping_rounds` is not set, the previously implemented stopping logic is used.

Not sure what's the best way to return the model from the best iteration. What's the current implementation doing in this regard? I mean, after `.fit()`, what iteration does the model use to `.predict()`?