### PR TITLE
Add feature importance functionality for tree learners

### DIFF
--- a/examples/inspections/Feature importance.ipynb
+++ b/examples/inspections/Feature importance.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load in Boston housing data set and train NGBoost model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../..\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[iter 0] loss=3.6483 val_loss=0.0000 scale=0.5000 norm=3.3928\n",
+      "[iter 100] loss=3.0937 val_loss=0.0000 scale=1.0000 norm=3.8307\n",
+      "[iter 200] loss=2.4551 val_loss=0.0000 scale=2.0000 norm=4.0511\n",
+      "[iter 300] loss=2.0437 val_loss=0.0000 scale=2.0000 norm=3.2047\n",
+      "[iter 400] loss=1.8457 val_loss=0.0000 scale=1.0000 norm=1.4397\n",
+      "Test MSE 6.215584751882489\n",
+      "Test NLL 2.590569145665296\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ngboost import NGBRegressor\n",
+    "\n",
+    "from sklearn.datasets import load_boston\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "\n",
+    "import pandas as pd\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "X, Y = load_boston(True)\n",
+    "X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=0.2)\n",
+    "\n",
+    "ngb = NGBRegressor().fit(X_train, Y_train)\n",
+    "Y_preds = ngb.predict(X_test)\n",
+    "Y_dists = ngb.pred_dist(X_test)\n",
+    "\n",
+    "# test Mean Squared Error\n",
+    "test_MSE = mean_squared_error(Y_preds, Y_test)\n",
+    "print('Test MSE', test_MSE)\n",
+    "\n",
+    "# test Negative Log Likelihood\n",
+    "test_NLL = -Y_dists.logpdf(Y_test.flatten()).mean()\n",
+    "print('Test NLL', test_NLL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Feature importance for each parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feature importance for loc trees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.07335516, 0.00416493, 0.02800235, 0.01143102, 0.05700804,\n",
+       "       0.21998733, 0.09810716, 0.13090997, 0.02697387, 0.06331768,\n",
+       "       0.06698812, 0.05752631, 0.16222807])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ngb.feature_importances_[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x2a48dbf7588>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZwAAAEWCAYAAABSaiGHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de7xUZdn/8c9XBAFRFPAQmm5F1JSUPPRkmWGWpyQlNcGs6GRHNc3qKfs90cmOZpmmj5mR9iRmpmlZaqlpainqRpTEs6mYKCiIoghcvz/WPbUYZ88e2HvWnL7v12terMO91lxrzWZfc6+19n0pIjAzM6u3tRodgJmZdQYnHDMzK4QTjpmZFcIJx8zMCuGEY2ZmhXDCMTOzQjjhmFnTknSdpA83Og7rH0441pQkPSxpqaQludfoPu5zgqTH+ivGGt9zuqSvF/mePZE0TdIvGh1HubLP+klJP5M0bDX30SUpJK1drzit75xwrJlNjIhhude8RgbTyr/MWiD2iRExDNgF2B34UoPjsTpwwrGWI+kNkm6S9KykWZIm5NZ9QNI/JD0n6UFJH03L1wX+AIzO95jKeyDlvaD07fvzku4Enpe0dtruYklPSXpI0rE1xl36Fv4BSY9KekbSxyTtLunOdDyn59pPlXSjpB9JWiTpHkn75NaPlnSZpIWS7pf0kdy6aZJ+LekXkhYDHwO+CByRjn1WtfOVPxeSPiNpvqQnJH0gt36IpFMkPZLi+6ukIb19RtVExOPpcxpX4fytJelL6f3mSzpP0vC0+vr077Pp+Pao5f2sWE441lIkbQb8Hvg6MAI4EbhY0kapyXzgIGB94APAqZJ2iYjngQOAeWvQY5oCvAPYAFgJXA7MAjYD9gE+LWm/1TiM/wLGAkcAPwBOAt4G7Ai8W9Jbyto+CIwCvgz8RtKItO4C4DFgNHAYcHI+IQEHA79Ocf8UOBm4MB37zqlNxfOV28emwPB0rB8CzpC0YVr3PWBX4I1kn8XngJU1fEY9kvRq4EDgjgqrp6bX3sDWwDCglKD3Sv9ukI7v5t7ey4rnhGPN7NL0DflZSZemZUcBV0TEFRGxMiKuBmaS/ZIiIn4fEQ9E5i/AVcCb+xjHaRHxaEQsJbvcs1FEfDUilkXEg8BPgMmrsb+vRcSLEXEV8DxwQUTMT9/ubwBel2s7H/hBRLwcERcCc4F3pF/MewKfT/vqBs4B3pvb9uaIuDSdp6WVAqnhfL0MfDW9/xXAEmA7SWsBHwSOi4jHI2JFRNwUES/Ry2fUg0slPQv8FfgLWXIs9x7g+xHxYEQsAb4ATG6By4WW+IOyZnZIRPypbNmWwOGSJuaWDQSuBZB0AFlPYFuyL1RDgdl9jOPRsvcfnX45lgwgSxS1ejI3vbTCfP6G+eOx6gi7j5D1aEYDCyPiubJ1u/UQd0U1nK8FEbE8N/9Cim8UMBh4oMJuq35GPaj0WZcbTXaMJY+Q/Q7bpJftrEk44VireRQ4PyI+Ur5C0jrAxcD7gN9GxMupZ6TUpNLQ6M+T/ZIt2bRCm/x2jwIPRcTYNQl+DWwmSbmkswVwGTAPGCFpvVzS2QJ4PLdt+fGuMl/D+armaeBFYAzZ5cW8Hj+jPppHlsxKtgCWkyXszfr5vawOfEnNWs0vgImS9pM0QNLgdHN7c2AQsA7wFLA8fXvfN7ftk8DI3I1mgG7gQEkjJG0KfLqX978FWJweJBiSYhgnafd+O8JVbQwcK2mgpMOB15BdrnoUuAn4ZjoHO5HdY/m/Kvt6EuhKl8Og9/PVo4hYCZwLfD89vDBA0h4piVX7jPriAuB4SVspe2y6dE9qeTqGlWT3dqxJOeFYS0m/aA8me+LqKbJv058F1krf9I8FfgU8AxxJ1hsobXsP2S+tB9N9odHA+WTf0B8mu39xYS/vvwKYCIwHHiL7pn8O2Y31evg72QMGTwPfAA6LiAVp3RSgi+yb/yXAl9P9kp5clP5dIOn23s5XDU4ku/x2K7AQ+DbZ59DjZ7Qa+67kXLLP63qyc/8icAxARLxAdn5uTJ/tG/r4XlYHcgE2s+YkaSrw4YjYs9GxmPUH93DMzKwQTjhmZlYIX1IzM7NCuIdjZmaF8N/hVDFq1Kjo6upqdBhmZi3jtttuezoiKg5j5IRTRVdXFzNnzmx0GGZmLUPSIz2tc8KpYvlTC3nqzKYrH2JmVjcbffyouu3b93DMzKwQTjhmZlYIJxwzMytEWyQcSSskdUu6S9LlkjZIy0sVFr+WaztK0svKVVY0M7P6a4uEAyyNiPERMY5sEMFP5tY9SFbRsORw4O4igzMzs/ZJOHk3s2ptjKXAPySVClMdQTY6rpmZFaitEo6kAWQ15suHWJ9BVop2c2AF2XDuPe3jaEkzJc1csGRx/YI1M+sw7ZJwhkjqBhYAI4DymiB/BN5OVj+kt3onZ0fEbhGx28hh69clWDOzTtQuCWdpRIwnKz87iFXv4RARy4DbgM+QldQ1M7OCtUvCASAiFpFVMDxR0sCy1acAn89VSzQzswK1VcIBiIg7yEoGTy5bfndE/LwxUZmZWVuMpRYRw8rmJ+Zmx1VoPx2YXt+ozMwsry0STr2svdGIug5kZ2bWSdrukpqZmTUnJxwzMyuEE46ZmRXC93CqWDb/YR47/YONDsPMerH5p85tdAhWA/dwzMysEE44ZmZWiKZJOJKWVFi2naTrUq2bf0g6W9J+ab5b0hJJc9P0ebntfijpcUlrpfkP5LZZJml2mv5WkcdoZtbJmv0ezmnAqRHxWwBJr42I2cCVaf464MSImFnaICWZScCjwF7AdRHxM+Bnaf3DwN4R8XSBx2Fm1vGapofTg1cBj5VmUrLpzd7AXcCZZKNDm5lZE2j2hHMqcI2kP0g6vlQ6uhdTgAuAS4CDKgziWVW+Hs7CJS+uQchmZlZJUyecdCnsNcBFwATgb5LW6am9pEHAgcClEbEY+Duw72q+57/r4YwYNniNYzczs1U1dcIBiIh5EXFuRBwMLKfCYJw5+wPDgdnpXs2e+LKamVlTaOqEI2n/0iUxSZsCI4HHq2wyBfhwRHRFRBewFbCvpKF1D9bMzKpqpqfUhkp6LDf/fWBz4IeSSjdTPhsR/6q0cUoq+wEfLS2LiOcl/RWYSC+lpc3MrL6aJuFERE+9rROqbDMhN/0CMKJCm3eVzXetWYRmZtYXTX1JzczM2kfT9HCa0aCNuzwooJlZP3EPx8zMCuGEY2ZmhfAltSqee/o+rj3nHY0Ow6wwe3/4940OwdqYezhmZlYIJxwzMyuEE46ZmRWi5ROOpBWpmNrdkmZJOiFXeG2CpN+l6U0k/S61mSPpisZGbmbWWdrhoYGlETEeQNLGwC/JBvD8clm7rwJXR8QPU9udCo3SzKzDtXwPJy8i5gNHA5+SpLLV5cXc7iwyNjOzTtdWCQcgIh4kO66Ny1adAfxU0rWSTpI0utL2+QJsi55bVu9wzcw6RtslnKS8d0NEXAlsDfwE2B64Q9JGFdr9uwDb8PUG1T9SM7MO0XYJR9LWwApgfvm6iFgYEb+MiPcCtwJ7FR2fmVmnaquEk3osZwGnR0SUrXtrqRCbpPWAMcA/i4/SzKwztcNTakMkdQMDyUpQn09WvK3crsDpkpaTJdpzIuLW4sI0M+tsLZ9wImJAlXXXAdel6e8C3y0mKjMzK9dWl9TMzKx5tXwPp57WGzXWo+eamfUT93DMzKwQTjhmZlYIX1KrYsGCe5n+830bHYa1mKnvv6rRIZg1JfdwzMysEE44ZmZWCCccMzMrREsmHEmTJIWk7XPLxqYCaw9Iui2NCr1XWjdV0lOpUFvptUPjjsDMrPO0ZMIBpgB/BSYDSBoM/B44OyLGRMSuwDFko0OXXBgR43OvOYVHbWbWwVou4UgaBrwJ+BAp4QDvAW6OiMtK7SLiroiYXnyEZmZWSSs+Fn0I8MeIuFfSQkm7ADsCt/ey3RGS9szN7xERS8sbSTqarGooI0cO7q+Yzcw6Xsv1cMgup81I0zPS/CokXSLpLkm/yS0uv6T2imQDqxZgW2+9gf0fvZlZh2qpHo6kkcBbgXGSAhgABPAVcsXUImKSpN2A7zUkUDMze4VW6+EcBpwXEVtGRFdEvBp4CLgXeJOkd+baDm1IhGZmVlFL9XDILp99q2zZxcCRwEHA9yX9AHgSeA74eq5d+T2cT0TETfUM1szM/qOlEk5ETKiw7LTc7IE9bDcdmF6XoMzMrCatdknNzMxaVEv1cIo2cuS2HvnXzKyfuIdjZmaFcMIxM7NC+JJaFY8/cx8nXbR/o8OwXnzj8D82OgQzq4F7OGZmVggnHDMzK0TTJxxJm0qakerczJF0haRtJS1NdW3mSDpP0sDUfoKk36Xpqaluzj65/ZVq6RzWqGMyM+tETZ1wJAm4BLgu1bnZAfgisAnwQESMB14LbA68u4fdzGbVAT4nA7PqF7WZmVXS1AkH2Bt4OSLOKi2IiG7g0dz8CuAWYLMe9nED8HpJA1MtnW2A7vqFbGZmlTR7whkH3FatQar2+V9AT48qBfAnYD/gYOCyHtqZmVkdNXvCqWaMpG5gAfDPiLizStsZZJfSJgMXVNuppKMlzZQ084XFy/ovWjOzDtfsCeduYNce1pXu4WwDvKGsNMEqIuIWst7SqIi4t9ob5guwDV1/0JrGbWZmZZo94VwDrCPpI6UFknYHtizNR8QTwH8DX+hlX18ge+DAzMwaoKkTTkQEMAl4e3os+m5gGjCvrOmlwFBJb66yrz9ExLV1C9bMzKpq+qFtImIelR95HpdrE8DOuXXXpeXTqVAHJyKm9mOIZmZWg6bu4ZiZWfto+h5OI2224VgPDGlm1k/cwzEzs0I44ZiZWSGccMzMrBC+h1PFfc8+zoGX+k93GumKQ05udAhm1k/cwzEzs0I44ZiZWSHqlnAkrUgF0u6SdJGkzdJ8t6R/SXo8Nz+orP3lkjYo29/xkl6UNDzN75fbfomkuWn6vHwRttT2EEl3SrpH0mxJh9TruM3MrLJ69nCWRsT4iBgHLAOOSPPjgbOAU0vzEbGsrP1C4JNl+5sC3Eo21A0RcWVufzOB96T59+U3krQz8D3g4IjYHngn8D1JO9Xv0M3MrFxRl9RuIBvVuVY3kyuoJmkMMAz4EqtW76zFicDJEfEQQPr3m8BnV3M/ZmbWB3VPOJLWBg4gK/VcS/sBwD6sWihtClkdmxuA7SRtvBoh7Mgri7jNTMsrvf+/6+EsW/zCaryNmZlVU8+EMyQVSJsJ/BP4aY3tFwAjgKtz6yYDMyJiJfAb4PDViENkVT97WwasWg9n0PpDV+NtzMysml4TjqRNJP1U0h/S/A6SPlTDvpfm7tEck+7T9NqerNbNINI9nHSvZSxwtaSHyZLP6lxWuxvYrWzZLsCc1diHmZn1US09nOnAlcDoNH8v8Ol6BRQRi4BjgRMlDSRLLtMioiu9RgObSdqy6o7+43vAFyR1AaR/vwic0s+hm5lZFbUknFER8StgJUBELAdW1DOoiLgDmEXWm5kMXFLW5JK0vJZ9dQOfBy6XdA9wOfC5tNzMzApSy9A2z0saSbrnIekNwKLeNoqIYVXWTeutfURMTJPnV2h7Qtn8hLL560hF2NL8b8ju/ZiZWYPUknBOIHtibIykG4GNgMPqGpWZmbWdqglH0lrAYOAtwHZkT3fNjYiXC4it4cZusJkHjzQz6ydVE05ErJR0SkTsQfa0l5mZ2Rqp5aGBqyQdKkl1j8bMzNpWrfdw1gWWS3qR9EeTEbF+XSNrAvc98zTvuPgnjQ6jI/z+0I80OgQzq7NeE05ErFdEIGZm1t56TTiS9qq0PCKu7/9wzMysXdVySS0/qvJg4PVkg2G+tS4RmZlZW+r1oYGImJh7vR0YBzxZ/9AqkzSyl0JukySFpO1z2+yWCrsNSvNjJD0oqe3vQ5mZNYs1GS36MbKk0xARsaCXQm5TgL+SG/omImYC15PVxgE4AzgpIhYXHL6ZWceq5R7Oj/jPUP5rAePJxjlrOpKGAW8C9iYbHWFabvUXgdslLQcGRsQFxUdoZta5armHMzM3vRy4ICJurFM8fXUI8MeIuFfSQkm7RMTtABHxrKRvAz8GduhpB5KOBo4GGDxqRBExm5l1hFouqW0QET9Pr/+LiBslHVf3yNbMFGBGmp7BK+vmHEB2/6nHhLNqATY/EW5m1l9qSTjvr7Bsaj/H0WdpROu3AuekQm2fBY4ojZAg6SBgOLAf8F1JLudpZlagHi+pSZoCHAlsJemy3Kr1yMpAN5vDgPMi4qOlBZL+AuwpaSZZwbVJETFH0m+Bk9LLzMwKUO0ezk3AE8AoVq2O+RxwZz2DWkNTgG+VLbuYLGkeAFwaEaWy0tOAbknTI+K+4kI0M+tcPSaciHgEeATYo7hwVk++kFt5Eba07LQetnsOGFO3wMzM7BV6vYcj6Q2SbpW0RNIySSsk+e9XzMxstdTyWPTpZH9EeRGwG/A+YJt6BtUsxm44yqMYm5n1k1oSDhFxv6QBEbEC+Jmkm+ocl5mZtZlaEs4LaQyybknfIXuQYN36hmVmZu2mloTzXrJ7PZ8CjgdeDRxaz6Caxf3PPMvEX1/S6DDawuWHTWp0CGbWYLUUYHtE0hDgVRHxlQJiMjOzNlTLU2oTgW7gj2l+fNkfgpqZmfWqlqFtppEVXXsWICK6ga76hWRmZu2oloSzPCIW1T2SOkt/P9QtaZak2yW9sdExmZl1kloeGrhL0pHAAEljgWPJhr1pNUtT0TYk7Qd8E3hLY0MyM+scPfZwJJ2fJh8AdgReAi4AFgOfrn9odbU+8EyjgzAz6yTVeji7StoSOIKsgmZ+AM+hwIv1DKwOhkjqBgYDryIrZfAK+QJsQ0ZtVFx0ZmZtrlrCOYvsybStWbXqp8hKTm9dx7jqIX9JbQ/gPEnjIiLyjSLibOBsgA3GbBOv3I2Zma2JHi+pRcRpEfEa4NyI2Dr32ioiWi3ZrCIibiYru+AujJlZQXp9Si0iPl5EIEWStD0wgOYsJGdm1pZqGryzTZTu4UB2WfD9aTBSMzMrQMcknIgY0OgYzMw6WccknDWxzYYbeNBJM7N+UstIA2ZmZn3mhGNmZoVwwjEzs0L4Hk4VDzzzPIdefEujw2h5Fx/6+kaHYGZNwD0cMzMrhBOOmZkVomUSjqSQdEpu/kRJ03LzR0u6J71ukbRnWj5A0m2S9sq1vUrS4YUegJlZh2uZhENWHuFdkkaVr5B0EPBRYM+I2B74GPBLSZum0QQ+AZwhaaCkKUBExEVFBm9m1ulaKeEsJxvF+fgK6z4PfDYingaIiNuBnwOfTPN/JysaNw04ubTczMyK00oJB+AM4D2Shpct3xG4rWzZzLS85AtkheN+GRH31y9EMzOrpKUSTkQsBs4jK3Pdm1LdnpK9gEXAuKobZfeCZkqa+dLiZ9c4VjMzW1VLJZzkB8CHgHVzy+YAu5a12yUtR9K6wHfIqnxuJOnAnnYeEWdHxG4Rsds662/Qr4GbmXWylks4EbEQ+BVZ0in5DvBtSSMBJI0HpgI/Tuv/B/hVRNxD9gDBqZIGFxa0mZm17EgDpwCfKs1ExGWSNgNukhTAc8BREfGEpB2AScDOqW23pCvJHjT4SvGhm5l1ppZJOBExLDf9JDC0bP2ZwJkVtpsDbFu2rJZ7QGZm1o9a7pKamZm1ppbp4TTCmA3X9cCTZmb9xD0cMzMrhBOOmZkVwgnHzMwK4Xs4VTz57Mt8/5J/NTqMHp0wadNGh2BmVjP3cMzMrBBOOGZmVoimSDiSlqR/u1KhtWNy606XNDVNT5f0kKRZku6VdF4aYWCV/eTmp0o6PU1vJ+k6Sd2S/iHp7EIOzszMgCZJOGXmA8dJGtTD+s9GxM7AdsAdwLVV2uadBpwaEeMj4jXAj/onXDMzq0UzJpyngD8D76/WKDKnAv8CDqhhv68CHsttP7svQZqZ2eppxoQD8C3gM5IG1ND2dmD7GtqdClwj6Q+SjpdUsfZAvh7O84sXrEbIZmZWTVMmnIh4CLgFOLKG5uptd2mfPwNeA1wETAD+JmmdCu/973o4664/crXiNjOznjVlwklOJish0FuMrwP+kaaXlt3PGQE8XZqJiHkRcW5EHAwsp5fqn2Zm1n+aNuGkYmlzgIMqrVfmWLJ7M39Mi/8CHJXWDwHeDVyb5veXNDBNbwqMBB6v5zGYmdl/NG3CSb4BbF627LuSZgH3ArsDe0fEsrTuOOBdkrqBvwEXRcT1ad2+wF1p2yvJnnZr3mEEzMzaTFMMbVMqrhYRD5O7zBURs8glxYiY2st+HqeHHlFEnACc0PdozcxsTTR7D8fMzNpEU/RwmtUmGwz0AJlmZv3EPRwzMyuEE46ZmRXCl9SqeG7hcq77xVONDqOiCUdt1OgQzMxWi3s4ZmZWCCccMzMrhBOOmZkVoqUSjqQVqYDaXZIuLx/xOY0C/aKk4bllEyQtknSHpLmSrpdU8Y9Dzcysfloq4QBLUwG1ccBC4JNl66cAtwKTypbfEBGvi4jtgGOB0yXtU/9wzcyspNUSTt7NQL689BhgGPAlssRTUUR0A18FPlXvAM3M7D9aMuGkwmz7AJflFk8BLgBuALaTtHGVXfRYtC1fgG2RC7CZmfWbVks4Q9JI0AvIat1cnVs3GZgRESuB3wCHV9lPj0Xb8gXYhrsAm5lZv2m1hLM0IsYDWwKDSPdwJO0EjAWulvQwWfLp8bIaqxZtMzOzArRawgEgIhaR3fw/MRVVmwJMi4iu9BoNbCZpy/JtU3L6f8AZhQZtZtbhWnZom4i4IxVTm5xeB5Q1uSQt/zvwZkl3AEOB+cCxEfHnIuM1M+t0LZVwSoXacvMT0+T5Fdrmi60NL19vZmbFaslLamZm1npaqodTtPVGrO1Rmc3M+ol7OGZmVggnHDMzK4QvqVXx8r9e5onvPLHG27/qc6/qx2jMzFqbezhmZlYIJxwzMyuEE46ZmRWiaROOpE0lzZD0gKQ5kq6QtK2ku8raTZN0Ym5+bUlPS/pmWbuDUhG2WWl/Hy3qWMzMrEkfGpAksqFpfh4Rk9Oy8cAmNWy+LzAXeLekL0ZEpPHWzgZeHxGPSVoH6KpP9GZmVkmz9nD2Bl6OiLNKC1LhtEdr2HYK8EPgn8Ab0rL1yJLrgrSvlyJibr9GbGZmVTVrwhkH3NbDujGSuksv4GOlFZKGkBVm+x1ZMbYpABGxkKxY2yOSLpD0HkkVjz1fgG3B8y7AZmbWX5o14VTzQESML72As3LrDgKujYgXgIuBSak6KBHxYbJkdAtwInBupZ3nC7CNXNcF2MzM+kuzJpy7gV3XYLspwNtSEbbbgJFkl+cAiIjZEXEq8Hbg0H6I08zMatSsCecaYB1JHyktkLQ7WaXPiiStD+wJbFEqxEZWEXSKpGGSJuSajwceqUfgZmZWWVMmnIgIYBLw9vRY9N3ANGBelc3eBVwTES/llv0WeCcwAPicpLnpvs9XgKn1iN3MzCpryseiASJiHvDuCqvGlbWblpudXrZuIVCqL3BgP4ZnZmarqWkTTjMYuOlAD8BpZtZPmvKSmpmZtR8nHDMzK4QTjpmZFcL3cKp4ef4Snjztr69YvsmxezYgGjOz1uYejpmZFcIJx8zMCtE2CUfSpPygnum1UtLHJYWkY3JtT5c0tYHhmpl1nLZJOBFxSdmgnj8GbgCuBOYDx0ka1NAgzcw6WNsknDxJ2wL/A7wXWAk8BfwZeH8j4zIz62Rtl3BSdc9fAidGxD9zq74FfKZUrqDK9v+uh7NwybP1DNXMrKO0XcIBvgbcHREz8gsj4iGyWjhHVts4Xw9nxLAN6himmVlnaau/w0klCA4FdumhycnAr4Hri4rJzMwybdPDkbQh8DPgfRHxXKU2EXEPMIesMqiZmRWonXo4HwM2Bs6UlF9+QVm7bwB3FBWUmZll2ibhRMQ3gW/2sPrbuXazaKOenZlZq/AvXjMzK0Tb9HDqYeDGwzxQp5lZP3EPx8zMCqGIaHQMTUvSc8DcRsfRxEYBTzc6iCbnc1Sdz091rXh+toyIjSqt8CW16uZGxG6NDqJZSZrp81Odz1F1Pj/Vtdv58SU1MzMrhBOOmZkVwgmnurMbHUCT8/npnc9RdT4/1bXV+fFDA2ZmVgj3cMzMrBBOOGZmVoiOTDiS9pc0V9L9kv67wvp1JF2Y1v9dUldu3RfS8rmS9isy7iKt6TmS1CVpqaTu9Dqr6NiLUMP52UvS7ZKWSzqsbN37Jd2XXm1ZhbaP52dF7ufnsuKiLlYN5+gESXMk3Snpz5K2zK1rzZ+hiOioFzAAeADYGhgEzAJ2KGvzCeCsND0ZuDBN75DarwNslfYzoNHH1GTnqAu4q9HH0ATnpwvYCTgPOCy3fATwYPp3wzS9YaOPqVnOT1q3pNHH0CTnaG9gaJr+eO7/WMv+DHViD+f1wP0R8WBELANmAAeXtTkY+Hma/jWwj7KaBwcDMyLipcgqiN6f9tdu+nKOOkGv5yciHo6IO4GVZdvuB1wdEQsj4hngamD/IoIuUF/OT6eo5RxdGxEvpNm/AZun6Zb9GerEhLMZ8Ghu/rG0rGKbiFgOLAJG1rhtO+jLOQLYStIdkv4i6c31DrYB+vJz0Ak/Q309xsGSZkr6m6RD+je0prG65+hDwB/WcNum0YlD21T6Fl7+bHhPbWrZth305Rw9AWwREQsk7QpcKmnHiFjc30E2UF9+DjrhZ6ivx7hFRMyTtDVwjaTZEfFAP8XWLGo+R5KOAnYD3rK62zabTuzhPAa8Oje/OTCvpzaS1gaGAwtr3LYdrPE5SpcbFwBExG1k16m3rXvExerLz0En/Az16RgjYl7690HgOuB1/Rlck6jpHEl6G3AS8M6IeGl1tm1GnZhwbgXGStpK0iCyG97lT8JcBpSe/DgMuCayu3WXAZPTE1pbAWOBWwqKu0hrfI4kbSRpAED6hjqW7KZmO6nl/PTkSmBfSRtK2hDYNy1rJ2t8ftJ5WSdNjwLeBMypW6SN0+s5kvQ64H/Jks383KrW/Rlq9FMLjXgBBwL3kn37Pikt+yrZBwswGLiI7KGAW4Ctc9uelLabCxzQ6GNptnMEHArcTfbUze3AxEYfS8n3sGkAAALuSURBVIPOz+5k30SfBxYAd+e2/WA6b/cDH2j0sTTT+QHeCMxOPz+zgQ81+lgaeI7+BDwJdKfXZa3+M+ShbczMrBCdeEnNzMwawAnHzMwK4YRjZmaFcMIxM7NCOOGYmVkhnHDM+omkmwp+vy5JRxb5nmZ94YRj1k8i4o1FvVca3aELcMKxluG/wzHrJ5KWRMQwSROAr5D90d544Ddkf8R4HDAEOCQiHpA0HXgR2BHYBDghIn4naTBwJtn4WcvT8mslTQXeQfZHt+sCQ4HXAA+Rjdx9CXB+WgfwqYi4KcUzDXgaGAfcBhwVESFpd+CHaZuXgH2AF4BvARPISnGcERH/28+nyzpQJw7eaVaEncmSwUKyoX3OiYjXSzoOOAb4dGrXRTYo4xjgWknbAJ8EiIjXStoeuEpSaTy6PYCdImJhSiQnRsRBAJKGAm+PiBcljQUuIEtakI1HtiPZmFs3Am+SdAtwIXBERNwqaX1gKdnIxIsiYvc0zMyNkq6KrCSH2RpzwjGrj1sj4gkASQ8AV6Xls8kKa5X8KiJWAvdJehDYHtgT+BFARNwj6RH+MwDq1RGxsIf3HAicLmk8sIJVB029JSIeS/F0kyW6RcATEXFreq/Faf2+wE65SpzDycbEc8KxPnHCMauPl3LTK3PzK1n1/135Ne2eymCUPF9l3fFkl/F2Jrs/+2IP8axIMajC+5OWHxMRrTEgpLUMPzRg1liHS1pL0hiycsNzgeuB9wCkS2lbpOXlngPWy80PJ+uxrATeS1bGuJp7gNHpPg6S1ksPI1wJfFzSwFIMktatsh+zmriHY9ZYc4G/kD008LF0/+XHwFmSZpM9NDA1Il6qUMH7TmC5pFnAdODHwMWSDgeupXpviIhYJukI4EeShpDdv3kbcA7ZJbfbU9nwp4B2rbxpBfJTamYNkp5S+11E/LrRsZgVwZfUzMysEO7hmJlZIdzDMTOzQjjhmJlZIZxwzMysEE44ZmZWCCccMzMrxP8Hu9S16f2QLL8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Feature importance plot\n",
+    "feature_importance = pd.DataFrame({'feature':load_boston()['feature_names'], \n",
+    "                                   'importance':ngb.feature_importances_[0]})\\\n",
+    "    .sort_values('importance',ascending=False).reset_index().drop(columns='index')\n",
+    "fig, ax = plt.subplots()\n",
+    "plt.title('Feature Importance Plot')\n",
+    "sns.barplot(x='importance',y='feature',ax=ax,data=feature_importance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feature importance for scale trees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.03499668, 0.03179946, 0.0421987 , 0.00305463, 0.06738745,\n",
+       "       0.23038586, 0.06233942, 0.09566871, 0.0359057 , 0.09357494,\n",
+       "       0.04821882, 0.08096553, 0.17350409])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ngb.feature_importances_[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x2a48dfb7088>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZwAAAEWCAYAAABSaiGHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de7xc49n/8c9XJISQSOIUyiaCakrq9NCqRtWxlBSVoBU96MGpNK0HfZ6mJ3pSdSqPKkp/RVGKOrbOh5YgEVSQoM4hQYQQSa7fH+verIzZsyfJzJrZM9/36zWvrHWvw1xrzc6+5l5r7ftSRGBmZlZvSzU6ADMzaw9OOGZmVggnHDMzK4QTjpmZFcIJx8zMCuGEY2ZmhXDCMbOmJekWSV9tdBxWG0441pQkPSVpjqTZudeQJdznSEnP1irGKt/zPEk/KfI9uyJpvKQ/NjqOUiWf9UuSzpXUbxH30SEpJC1drzhtyTnhWDPbPSL65V7PNzKYnvzLrAfEvntE9AM2BbYAvt/geKwOnHCsx5G0laS7JL0maZKkkbllB0n6t6Q3JE2T9PXUvjxwLTAk32Mq7YGU9oLSt++jJT0IvClp6bTdZZJelvSkpMOrjLvzW/hBkp6R9Kqkb0jaQtKD6XhOy60/VtKdkk6V9LqkRyVtn1s+RNKVkmZKekLS13LLxku6VNIfJc0CvgEcC+ybjn1SpfOVPxeSviNpuqQXJB2UW95X0omSnk7x3SGpb3efUSUR8Vz6nIaXOX9LSfp+er/pks6X1D8tvi39+1o6vq2reT8rlhOO9SiS1gD+BvwEGAiMAy6TtHJaZTqwG7AicBBwkqRNI+JNYBfg+cXoMY0BPgsMABYAVwGTgDWA7YFvS9ppEQ7jv4BhwL7Ab4DjgM8AHwG+IOlTJetOAwYDPwD+ImlgWnYh8CwwBNgbOD6fkIA9gEtT3L8HjgcuTse+SVqn7PnK7WM1oH861q8Ap0taKS37FbAZ8HGyz+J7wIIqPqMuSfoQsCvwQJnFY9NrO2BdoB/QmaC3Tf8OSMd3d3fvZcVzwrFmdkX6hvyapCtS2wHANRFxTUQsiIgbgQlkv6SIiL9FxNTI3ArcAHxyCeM4JSKeiYg5ZJd7Vo6IH0XE3IiYBvwOGL0I+/txRLwdETcAbwIXRsT09O3+duBjuXWnA7+JiHcj4mJgCvDZ9It5G+DotK+JwNnAF3Pb3h0RV6TzNKdcIFWcr3eBH6X3vwaYDWwgaSngy8AREfFcRMyPiLsi4h26+Yy6cIWk14A7gFvJkmOp/YFfR8S0iJgNHAOM7gGXCy3xB2XNbM+I+HtJ29rAPpJ2z7X1Bm4GkLQLWU9gfbIvVMsBk5cwjmdK3n9I+uXYqRdZoqjWS7npOWXm8zfMn4uFR9h9mqxHMwSYGRFvlCzbvIu4y6rifM2IiHm5+bdSfIOBZYGpZXZb8TPqQrnPutQQsmPs9DTZ77BVu9nOmoQTjvU0zwAXRMTXShdIWga4DPgS8NeIeDf1jJRWKTc0+ptkv2Q7rVZmnfx2zwBPRsSwxQl+MawhSbmksxZwJfA8MFDSCrmksxbwXG7b0uNdaL6K81XJK8DbwFCyy4t5XX5GS+h5smTWaS1gHlnCXqPG72V14Etq1tP8Edhd0k6SeklaNt3cXhPoAywDvAzMS9/ed8xt+xIwKHejGWAisKukgZJWA77dzfvfA8xKDxL0TTEMl7RFzY5wYasAh0vqLWkf4MNkl6ueAe4CTkjnYGOyeyz/r8K+XgI60uUw6P58dSkiFgDnAL9ODy/0krR1SmKVPqMlcSFwpKR1lD023XlPal46hgVk93asSTnhWI+SftHuQfbE1ctk36a/CyyVvukfDvwZeBXYj6w30Lnto2S/tKal+0JDgAvIvqE/RXb/4uJu3n8+sDswAniS7Jv+2WQ31uvhX2QPGLwC/BTYOyJmpGVjgA6yb/6XAz9I90u6ckn6d4ak+7s7X1UYR3b57V5gJvBzss+hy89oEfZdzjlkn9dtZOf+beAwgIh4i+z83Jk+262W8L2sDuQCbGbNSdJY4KsRsU2jYzGrBfdwzMysEE44ZmZWCF9SMzOzQriHY2ZmhfDf4VQwePDg6OjoaHQYZmY9xn333fdKRJQdxsgJp4KOjg4mTJjQ6DDMzHoMSU93tcwJp4J5L8/k5TOarnyImVndrPzNA+q2b9/DMTOzQjjhmJlZIZxwzMysEC2RcCTNlzRR0kOSrpI0ILV3Vlj8cW7dwZLeVa6yopmZ1V9LJBxgTkSMiIjhZIMIHpJbNo2somGnfYCHiwzOzMxaJ+Hk3c3CtTHmAP+W1FmYal+y0XHNzKxALZVwJPUiqzFfOsT6RWSlaNcE5pMN597VPg6WNEHShBmzZ9UvWDOzNtMqCaevpInADGAgUFoT5DpgB7L6Id3VOzkrIjaPiM0H9VuxLsGambWjVkk4cyJiBFn52T4sfA+HiJgL3Ad8h6ykrpmZFaxVEg4AEfE6WQXDcZJ6lyw+ETg6Vy3RzMwK1FIJByAiHiArGTy6pP3hiPhDY6IyM7OWGEstIvqVzO+emx1eZv3zgPPqG5WZmeW1RMKpl6VXHljXgezMzNpJy11SMzOz5uSEY2ZmhXDCMTOzQvgeTgVzpz/Fs6d9udFhmNliWPPQcxodgpVwD8fMzArhhGNmZoVomoQjaXaZtg0k3ZJq3fxb0lmSdkrzEyXNljQlTZ+f2+5kSc9JWirNH5TbZq6kyWn6Z0Ueo5lZO2v2ezinACdFxF8BJH00IiYD16f5W4BxETGhc4OUZEYBzwDbArdExLnAuWn5U8B2EfFKgcdhZtb2mqaH04XVgWc7Z1Ky6c52wEPAGWSjQ5uZWRNo9oRzEnCTpGslHdlZOrobY4ALgcuB3coM4llRvh7OzNlvL0bIZmZWTlMnnHQp7MPAJcBI4J+SlulqfUl9gF2BKyJiFvAvYMdFfM/36uEM7LfsYsduZmYLa+qEAxARz0fEORGxBzCPMoNx5uwM9Acmp3s12+DLamZmTaGpE46knTsviUlaDRgEPFdhkzHAVyOiIyI6gHWAHSUtV/dgzcysomZ6Sm05Sc/m5n8NrAmcLKnzZsp3I+LFchunpLIT8PXOtoh4U9IdwO50U1razMzqq2kSTkR01ds6qsI2I3PTbwEDy6zz+ZL5jsWL0MzMlkRTX1IzM7PW0TQ9nGbUZ5UODwBoZlYj7uGYmVkhnHDMzKwQvqRWwRuvPM7NZ3+20WFYk9juq39rdAhmPZp7OGZmVggnHDMzK4QTjpmZFaLHJxxJ81MxtYclTZJ0VK7w2khJV6fpVSVdndZ5RNI1jY3czKy9tMJDA3MiYgSApFWAP5EN4PmDkvV+BNwYESendTcuNEozszbX43s4eRExHTgYOFSSShaXFnN7sMjYzMzaXUslHICImEZ2XKuULDod+L2kmyUdJ2lIue3zBdhef2NuvcM1M2sbLZdwktLeDRFxPbAu8DtgQ+ABSSuXWe+9Amz9V+hT/0jNzNpEyyUcSesC84HppcsiYmZE/CkivgjcC2xbdHxmZu2qpRJO6rGcCZwWEVGy7NOdhdgkrQAMBf5TfJRmZu2pFZ5S6ytpItCbrAT1BWTF20ptBpwmaR5Zoj07Iu4tLkwzs/bW4xNORPSqsOwW4JY0/Uvgl8VEZWZmpVrqkpqZmTWvHt/DqacVBg/zCMFmZjXiHo6ZmRXCCcfMzArhS2oVzJjxGOf9YcdGh2ENNPbAGxodglnLcA/HzMwK4YRjZmaFcMIxM7NC9LiEI2lQKrg2UdKLkp7LzfeRNEpSSNowt83mkh6S1CfND5U0TdKKjTsSM7P20uMSTkTMiIgRqejamcBJnfMRMRcYA9wBjM5tMwG4DRiXmk4HjouIWQWHb2bWtlrqKTVJ/YBPANsBVwLjc4uPBe5PY6n1jogLi4/QzKx9tVTCAfYErouIxyTNlLRpRNwPEBGvSfo58Ftgo652IOlgsqqhDBq0bBExm5m1hR53Sa0bY4CL0vRFaT5vF+AlKiScfAG2FVboXZ8ozczaUMv0cCQNAj4NDJcUQC8gJH0vIkLSbkB/YCfgcknXR8RbDQzZzKyttFIPZ2/g/IhYOyI6IuJDwJPANpL6AicCh0TEZOCvwHENjNXMrO20UsIZA1xe0nYZsB/wP8AVEfFIah8PjJY0rLjwzMzaW4++pBYR43PTI8ssP6WL7d4gKzFtZmYFaaUejpmZNbEe3cOpt0GD1vdowWZmNeIejpmZFcIJx8zMCuFLahU89+rjHHfJzo0OwxbTT/e5rtEhmFmOezhmZlYIJxwzMytE2yQcSfNTzZxJku6X9PFGx2Rm1k7a6R7OnFRDB0k7AScAn2psSGZm7aNtejglVgRebXQQZmbtpJ16OH0lTQSWBVYnG1nazMwK0k4JJ39JbWvgfEnDIyLyK+ULsK042AXYzMxqpS0vqUXE3cBgYOUyy94rwLbcin2KD87MrEW1ZcKRtCFZgbYZjY7FzKxdtNMltc57OAACDoyI+Y0MyMysnbRNwomIXo2OwcysnbXlJTUzMyte2/RwFscaKw3zAJBmZjXiHo6ZmRXCCcfMzArhhGNmZoXwPZwKHn/tOXa94thGh9FWrtnz+EaHYGZ14h6OmZkVwgnHzMwK0WMSjqSQdGJufpyk8bn5gyU9ml73SNomtfeSdJ+kbXPr3iBpn0IPwMyszfWYhAO8A3xe0uDSBZJ2A74ObBMRGwLfAP4kabU0fM23gNMl9ZY0BoiIuKTI4M3M2l1PSjjzgLOAI8ssOxr4bkS8AhAR9wN/AA5J8/8C7gLGA8d3tpuZWXF6UsIBOB3YX1L/kvaPAPeVtE1I7Z2OAb4N/CkinujqDdKluQmSJsyd9VYtYjYzM3pYwomIWcD5wOFVrC4gX1xtW+B1YHg37/FePZw+Ky632LGamdnCuk04klaV9HtJ16b5jSR9pf6hdek3wFeA5XNtjwCblay3aWpH0vLAL8jKSq8sadcC4jQzs5xqejjnAdcDQ9L8Y2SXphoiImYCfyZLOp1+Afxc0iAASSOAscBv0/L/Bf4cEY+SPUBwkiTXjzYzK1A1CWdwRPwZWAAQEfOARhcuO5GsRDQAEXElcA5wl6RHgd8BB0TEC5I2AkYBP03rTiRLoEcXHrWZWRurZmibN1PPIQAkbUV2L6RQEdEvN/0SsFzJ8jOAM8ps9wiwfklbNfeAzMyshqpJOEcBVwJDJd0JrAzsXdeozMys5VRMOJKWApYFPgVsQPbk15SIeLeA2Bpu2IA1PJikmVmNVEw4EbFA0okRsTXwcEExmZlZC6rmoYEbJO0lSXWPxszMWla193CWB+ZJepv0B5URsWJdI2sCj7/6Cp+97HeNDqPl/G2vrzU6BDNrgG4TTkSsUEQgZmbW2rpNOPlh/fMi4rbah2NmZq2qmktq381NLwtsSTZQ5qfrEpGZmbWkbh8aiIjdc68dyAa/fKn+oXVN0qhUkG3DXNswSVdLmpoKrt3c2TuTNFbSy5Im5l4bNe4IzMzaz+KMFv0s3Yy4XIAxwB3AaIA0LtrfgLMiYmhEbAYcBqyb2+biiBiRez1SeNRmZm2smns4p/L+MP9LASOASfUMqpt4+gGfALYjGwFhPLA/cHcaUw2AiHgIeKgRMZqZ2QdVcw9nQm56HnBhRNxZp3iqsSdwXUQ8JmmmpE3JCq3d3812+0raJje/dUTMKV1J0sHAwQDLDh5Yq5jNzNpeNQlnQEScnG+QdERpW4HGkNXEAbgozS9E0uXAMOCxiPh8ar44Ig7tbucRcRZZKWv6D+2IblY3M7MqVXMP58AybWNrHEdV0qjVnwbOlvQU2RN0+5INu7Np53oRMYosRndRzMyaRJc9HEljgP2AdSRdmVu0AjCj3oF1YW/g/Ij4emeDpFvJisIdI+lzufs4rg9tZtZEKl1Suwt4gazQ2Ym59jeAB+sZVAVjgJ+VtF1Glhh3A34t6Tdkj22/Afwkt17pPZxvRcRd9QzWzMze12XCiYingaeBrYsLp7KIGFmm7ZTc7K5dbHceWalsMzNrkG7v4UjaStK9kmZLmitpvqRZRQRnZmato5qn1E4j+wPLS4DNgS8B69UzqGYxbKXBHtnYzKxGqkk4RMQTknpFxHzgXEm+92FmZoukmoTzlqQ+wERJvyB7kGD5+oZlZmatppqE80Wyez2HAkcCHwL2qmdQzeKJV19j90svb3QYDXfV3qMaHYKZtYBqCrA9LakvsHpE/LCAmMzMrAVV85Ta7sBE4Lo0P6LkD0HNzMy6Vc3QNuPJiq69BhARE4GO+oVkZmatqJqEMy8iXl/UHae/15ko6SFJl0haI1f87EVJz+Xm+5Ssf5WkASX7O1LS25L6p/mdctvPljQlTZ8vaaSkq3Pb7inpQUmPSposac9FPR4zM1sy1SSchyTtB/RKVTVPJRv2pjtzUqGz4cBcYN/O4mfAmcBJuWJoc0vWnwkcUrK/McC9wCiAiLg+t78JwP5p/kv5jSRtAvwK2CMiNgQ+B/xK0sZVHIOZmdVIlwlH0gVpcipZvZl3gAuBWcC3F/F9bmfR/lj0bmCNXCxDgX7A9ylTjqAb44DjI+JJgPTvCWQjTZuZWUEq9XA2k7Q22fD/JwI7ATum6apHYpa0NLALMLnK9XsB25NV8+w0hizZ3Q5sIGmVat+fLFneV9I2IbWXe/+DJU2QNGHuLI/gY2ZWK5Ueiz6T7Mm0dVm46qfISk6v282++0qamKZvB35f5fodZAnixtyy0cCoiFgg6S/APsDp3eyvNN7u2oCFC7ANGLqeC7CZmdVIpdGiTwFOkXRGRHxzMfY9J91fWaT100MBV5Pdwzkl3WsZBtwoCaAPMI3qE87DZGPA5UsqbAo8sgixmZnZEur2oYHFTDaLLT0RdzgwTlJvsstp4yOiI72GAGuky33V+BVZcbYOgPTvsSxc48fMzOqsmqfUChcRDwCTyC6ljQZKx5e5PLVXs6+JwNHAVZIeBa4CvpfazcysIIrwbYquDBi6Xnzy579sdBgN57HUzKxaku6LiM3LLauqPEG7Wm+lAf5la2ZWI015Sc3MzFqPE46ZmRXCCcfMzArhezgVTH31Tfa67J5Gh1F3l+21ZaNDMLM24B6OmZkVwgnHzMwK0RQJR9Ls9G+HpJB0WG7ZaZLGpunzJD0paZKkx1LtmzVK95ObHyvptDS9gaRbUs2cf0s6q5CDMzMzoEkSTonpwBGS+nSx/LsRsQmwAfAAcHOFdfNO4f0aPB8GTq1NuGZmVo1mTDgvA/8ADqy0UmROAl4kK3/QndWBZ3PbV1UuwczMaqMZEw7Az4DvpNo43bkf2LCK9U4CbpJ0bSpXPaDbLczMrGaaMuGkqpz3APtVsbq6213a57nAh4FLgJHAPyUt84Gd5QqwvTPrtUWK28zMutaUCSc5nmyU5+5i/Bjw7zQ9p+R+zkDglc6ZiHg+Is6JiD2AecDw0p1FxFkRsXlEbL7Miu4EmZnVStMmnIh4lKxI2m7llitzONm9metS863AAWl5X+ALwM1pfudUXwdJqwGDgOfqeQxmZva+pk04yU+BNUvafilpEvAYsAWwXUTMTcuOAD6fSlX/E7gkIm5Ly3YEHkrbXk/2tNuLdT8CMzMDmmRom4jol/59itxlroiYRC4pRsTYbvbzHF30iCLiKOCoJY/WzMwWR7P3cMzMrEU0RQ+nWQ1daXkPbGlmViPu4ZiZWSGccMzMrBBOOGZmVgjfw6ngpdfe5deX9+wnp48atVqjQzAzA9zDMTOzgjjhmJlZIXpUwpE0PxVQe0jSVaUjPqdRoN+W1D/XNlLS65IekDRF0m2Syv5xqJmZ1U+PSjjAnFRAbTgwEzikZPkY4F5gVEn77RHxsYjYADgcOE3S9vUP18zMOvW0hJN3N5AvLz0U6Ad8nyzxlBURE4EfAYfWO0AzM3tfj0w4qTDb9sCVueYxwIXA7cAGklapsIsui7bl6+G8OWtGrUI2M2t7PS3h9E0jQc8gq3VzY27ZaOCiiFgA/AXYp8J+uizalq+Hs/yKg2oRs5mZ0fMSzpyIGAGsDfQh3cORtDEwDLhR0lNkyafLy2osXLTNzMwK0NMSDgAR8TrZzf9xqajaGGB8RHSk1xBgDUlrl26bktP/AKcXGrSZWZvrsSMNRMQDqZja6PTapWSVy1P7v4BPSnoAWA6YDhweEf8oMl4zs3bXoxJOZ6G23PzuafKCMuvmi631L11uZmbF6pGX1MzMrOfpUT2coq06oLcHvzQzqxH3cMzMrBBOOGZmVghfUqvgjZnzuOWPLzc6jMU28oCVGx2Cmdl73MMxM7NCOOGYmVkhnHDMzKwQTZ9wJK0m6SJJUyU9IukaSetLmpOKsT0i6fw0xE1nwbWr0/RYSZGvfSNpVGrbu1HHZGbWjpo64UgS2RA1t0TE0IjYCDgWWBWYmgby/CiwJvCFLnYzmYUH8hwNTKpf1GZmVk5TJxxgO+DdiDizsyEVUHsmNz8fuIdcMbYStwNbSuotqR+wHjCxfiGbmVk5zZ5whgP3VVpB0rLAfwHXdbFKAH8HdgL2YOGibeX2914BttddgM3MrGaaPeFUMjRXjO0/EfFghXUv4v1RpS+stNN8Abb+LsBmZlYzzZ5wHgY262JZ5z2c9YCtJH2uq51ExD1kvaXBEfFY7cM0M7PuNHvCuQlYRtLXOhskbUFW8ROAiHgB+G/gmG72dQzZAwdmZtYATZ1wIiKAUcAO6bHoh4HxwPMlq14BLCfpkxX2dW1E3Fy3YM3MrKKmH0stIp6n/CPPw3PrBLBJbtktqf084Lwy+xxbwxDNzKwKTd3DMTOz1tH0PZxGWmHg0h5x2cysRtzDMTOzQjjhmJlZIXxJrYJ3X3yXF37xQqPDqNrq31u90SGYmXXJPRwzMyuEE46ZmRXCCcfMzArRMgknFVabWPJaIOmbqeDaYbl1T5M0toHhmpm1nZZJOBFxeUSM6HwBvyWrhXM9MB04QlKfhgZpZtbGWibh5ElaH/hf4IvAAuBl4B/AgY2My8ysnbVcwpHUG/gTMC4i/pNb9DPgO5J6dbP9ewXYZrzpAmxmZrXScgkH+DHwcERclG+MiCfJSlHvV2njfAG2Qcu7AJuZWa201B9+ShoJ7AVs2sUqxwOXArcVFZOZmWVapocjaSXgXOBLEfFGuXUi4lHgEWC3ImMzM7PW6uF8A1gFOENSvv3CkvV+CjxQVFBmZpZpmYQTEScAJ3Sx+Oe59SbRQj07M7OeomUSTj30Xq23B8Q0M6sRf9M3M7NCOOGYmVkhnHDMzKwQvodTwbvTZ/PSKXe8N7/q4ds0MBozs57NPRwzMyuEE46ZmRWiaROOpNUkXSRpqqRHJF0jaX1JD5WsN17SuNz80pJekXRCyXq7SXpA0qS0v68XdSxmZtak93CUDRVwOfCHiBid2kYAq1ax+Y7AFOALko6NiEgjSJ8FbBkRz0paBuioT/RmZlZOs/ZwtgPejYgzOxsiYiLwTBXbjgFOBv4DbJXaViBLrjPSvt6JiCk1jdjMzCpq1oQzHLivi2VD82WkycZQA0BSX2B74GqyMdTGAETETOBK4GlJF0raX1LZY8/Xw5k5+7UaHpKZWXtr1oRTydSSUtJn5pbtBtwcEW8BlwGjOguuRcRXyZLRPcA44JxyO8/XwxnYb0BdD8TMrJ00a8J5GNhsMbYbA3xG0lNkPaRBZJfnAIiIyRFxErADWd0cMzMrSLMmnJuAZSR9rbNB0hbA2l1tIGlFYBtgrYjoiIgO4BBgjKR+qThbpxHA0/UI3MzMymvKhBMRAYwCdkiPRT8MjAeer7DZ54GbIuKdXNtfgc8BvYDvSZqS7vv8EBhbj9jNzKy8pnwsGiAinge+UGbR8JL1xudmzytZNhNYOc3uWsPwzMxsETVlD8fMzFpP0/ZwmkHvVfp5wE4zsxpxD8fMzAqh7P68lSPpDbJhcux9g4FXGh1Ek/E5+SCfkw9ql3OydkSsXG6BL6lVNiUiNm90EM1E0gSfk4X5nHyQz8kH+Zz4kpqZmRXECcfMzArhhFPZWY0OoAn5nHyQz8kH+Zx8UNufEz80YGZmhXAPx8zMCuGEY2ZmhWjLhCNp5zSQ5xOS/rvM8mUkXZyW/0tSR27ZMal9iqSdioy7nhb3nEjqkDQnVxTvzNJte7Iqzsu2ku6XNE/S3iXLDpT0eHodWFzU9bWE52R+7mflyuKirq8qzslRkh6R9KCkf0haO7esJX9OyoqItnqRjRw9FVgX6ANMAjYqWedbwJlpejRwcZreKK2/DLBO2k+vRh9Tg89JB/BQo4+hgeelA9gYOB/YO9c+EJiW/l0pTa/U6GNq5DlJy2Y3+hgadE62A5ZL09/M/f9pyZ+Trl7t2MPZEngiIqZFxFzgImCPknX2AP6Qpi8Ftpek1H5RRLwTEU8CT6T99XRLck5aWbfnJSKeiogHgQUl2+4E3BgRMyPiVeBGYOcigq6zJTknraqac3JzZJWIAf4JrJmmW/XnpKx2TDhrAM/k5p9NbWXXiYh5wOtk1UOr2bYnWpJzArCOpAck3Srpk/UOtkBL8nm3889KJctKmiDpn5L2rG1oDbOo5+QrwLWLuW2P1o5D25T7Vl76bHhX61SzbU+0JOfkBbIqqzMkbQZcIekjETGr1kE2wJJ83u38s1LJWhHxvKR1gZskTY6IqTWKrVGqPieSDgA2Bz61qNu2gnbs4TwLfCg3vyYfrCT63jqSlgb6AzOr3LYnWuxzki4vzgCIiPvIrmWvX/eIi7Ekn3c7/6x0KbLCikTENOAW4GO1DK5Bqjonkj4DHAd8Lt6vTNyqPydltWPCuRcYJmkdSX3IboCXPi1zJdD5tMjeZKWrI7WPTk9srQMMA+4pKO56WuxzImllSb0A0rfWYWQ3PltBNeelK9cDO0paSdJKwI6pradb7HOSzsUyaXow8AngkbpFWpxuz4mkjwH/R5ZspucWterPSXmNfmqhES+yctOPkX0bPy61/YjshwFgWeASsocC7gHWzW17XNpuCrBLo4+l0ecE2At4mOzJnPuB3Rt9LAWfly3IvqW+CcwAHs5t++V0vp4ADmr0sTT6nAAfBxyOEsIAAALRSURBVCann5XJwFcafSwFnpO/Ay8BE9Prylb/OSn38tA2ZmZWiHa8pGZmZg3ghGNmZoVwwjEzs0I44ZiZWSGccMzMrBBOOGY1Iumugt+vQ9J+Rb6n2ZJwwjGrkYj4eFHvlUZ76ACccKzH8N/hmNWIpNkR0U/SSOCHZH/oNwL4C9kfOh4B9AX2jIipks4D3gY+AqwKHBURV0taFjiDbMytean9Zkljgc+S/RHu8sBywIeBJ8lG8r4cuCAtAzg0Iu5K8YwHXgGGA/cBB0RESNoCODlt8w6wPfAW8DNgJFkpjtMj4v9qfLqsDbXj4J1mRdiELBnMJBvq5+yI2FLSEcBhwLfTeh1kAzkOBW6WtB5wCEBEfFTShsANkjrHp9sa2DgiZqZEMi4idgOQtBywQ0S8LWkYcCFZ0oJszLKPkI3TdSfwCUn3ABcD+0bEvZJWBOaQjWb8ekRskYaiuVPSDZGV5DBbbE44ZvVxb0S8ACBpKnBDap9MVoyr058jYgHwuKRpwIbANsCpABHxqKSneX9A1BsjYmYX79kbOE3SCGA+Cw+iek9EPJvimUiW6F4HXoiIe9N7zUrLdwQ2zlXr7E82Rp4Tji0RJxyz+ngnN70gN7+Ahf/flV7T7qoMRqc3Kyw7kuwy3iZk92ff7iKe+SkGlXl/UvthEdG6g0haQ/ihAbPG2kfSUpKGkpUongLcBuwPkC6lrZXaS70BrJCb70/WY1kAfJGs9HEljwJD0n0cJK2QHka4HvimpN6dMUhavsJ+zKriHo5ZY00BbiV7aOAb6f7Lb4EzJU0me2hgbES8U6ai94PAPEmTgPOA3wKXSdoHuJnKvSEiYq6kfYFTJfUlu3/zGeBssktu96cy4i8DrVKd0xrIT6mZNUh6Su3qiLi00bGYFcGX1MzMrBDu4ZiZWSHcwzEzs0I44ZiZWSGccMzMrBBOOGZmVggnHDMzK8T/B73qfSiev5wLAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Feature importance plot\n",
+    "feature_importance = pd.DataFrame({'feature':load_boston()['feature_names'], \n",
+    "                                   'importance':ngb.feature_importances_[1]})\\\n",
+    "    .sort_values('importance',ascending=False).reset_index().drop(columns='index')\n",
+    "fig, ax = plt.subplots()\n",
+    "plt.title('Feature Importance Plot')\n",
+    "sns.barplot(x='importance',y='feature',ax=ax,data=feature_importance)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -198,6 +198,7 @@ class NGBoost(object):
         """
         Return the feature importances for all parameters in the distribution
             (the higher, the more important the feature).
+
         Returns
         -------
         feature_importances_ : array, shape = [n_params, n_features]

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -193,3 +193,34 @@ class NGBoost(object):
     def staged_predict(self, X, max_iter=None):
         return [self.dist_to_prediction(dist) for dist in self.staged_pred_dist(X, max_iter=None)]
 
+    @property
+    def feature_importances_(self):
+        """
+        Return the feature importances for all parameters in the distribution
+            (the higher, the more important the feature).
+        Returns
+        -------
+        feature_importances_ : array, shape = [n_params, n_features]
+            The summation along second axis of this array is an array of ones, 
+            unless all trees are single node trees consisting of only the root 
+            node, in which case it will be an array of zeros.
+        """
+        # Check whether the model is fitted
+        if not self.base_models:
+            return None
+        # Check whether the base model is DecisionTreeRegressor
+        if not 'sklearn.tree.tree.DecisionTreeRegressor' in str(type(self.base_models[0][0])):
+            return None
+        # Reshape the base_models
+        params_trees = zip(*self.base_models)
+        # Get the feature_importances_ for all the params and all the trees
+        all_params_importances = [[getattr(tree, 'feature_importances_') 
+            for tree in trees if tree.tree_.node_count > 1] 
+                for trees in params_trees]
+
+        if not all_params_importances:
+            return np.zeros(len(self.base_models[0]),self.base_models[0][0].n_features_, dtype=np.float64)
+        # Weighted average of importance by tree scaling factors
+        all_params_importances = np.average(all_params_importances,
+                                  axis=1, weights=self.scalings)
+        return all_params_importances / np.sum(all_params_importances,axis=1,keepdims=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fastcache==1.1.0
 future==0.17.1
 joblib==0.14.0
 kiwisolver==1.1.0
-lifelines==0.22.8
+lifelines==0.23.4
 matplotlib==3.1.1
 numpy==1.17.2
 opt-einsum==3.1.0


### PR DESCRIPTION
Follow-up on #27. 
For default_tree_learners, added sklearn-like feature importance.
The resulting feature importance is a numpy array with number of parameters in the distribution as number of rows and number of features in the training data as number of columns.

Please check out the [notebook](https://github.com/zhiruiwang/ngboost/blob/feature_importance/examples/inspections/Feature%20importance.ipynb) for testing examples.