### PR TITLE
Manifold refactor

### DIFF
--- a/ngboost/__init__.py
+++ b/ngboost/__init__.py
@@ -1,4 +1,4 @@
 from .ngboost import NGBoost
 from .api import NGBClassifier, NGBRegressor, NGBSurvival
 
-__version__ = "0.1.5dev"
+__version__ = "0.2.0dev"

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -1,7 +1,7 @@
 import numpy as np
 from ngboost.ngboost import NGBoost
 from ngboost.distns import Bernoulli, Normal, LogNormal
-from ngboost.scores import MLE
+from ngboost.scores import LogScore
 from ngboost.learners import default_tree_learner
 from sklearn.base import BaseEstimator
 
@@ -10,7 +10,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
 
     def __init__(self,
                  Dist=Normal,
-                 Score=MLE,
+                 Score=LogScore,
                  Base=default_tree_learner,
                  natural_gradient=True,
                  n_estimators=500,
@@ -30,7 +30,7 @@ class NGBClassifier(NGBoost, BaseEstimator):
 
     def __init__(self,
                  Dist=Bernoulli,
-                 Score=MLE,
+                 Score=LogScore,
                  Base=default_tree_learner,
                  natural_gradient=True,
                  n_estimators=500,
@@ -56,7 +56,7 @@ class NGBSurvival(NGBoost, BaseEstimator):
 
     def __init__(self,
                  Dist=LogNormal,
-                 Score=MLE,
+                 Score=LogScore,
                  Base=default_tree_learner,
                  natural_gradient=True,
                  n_estimators=500,

--- a/ngboost/distns/__init__.py
+++ b/ngboost/distns/__init__.py
@@ -1,4 +1,4 @@
-from .distn import Distn, manifold
+from .distn import RegressionDistn, ClassificationDistn
 from .normal import Normal, NormalFixedVar
 from .multivariate_normal import MultivariateNormal
 from .lognormal import LogNormal

--- a/ngboost/distns/__init__.py
+++ b/ngboost/distns/__init__.py
@@ -1,4 +1,4 @@
-from .distn import Distn
+from .distn import Distn, manifold
 from .normal import Normal, NormalFixedVar
 from .multivariate_normal import MultivariateNormal
 from .lognormal import LogNormal

--- a/ngboost/distns/distn.py
+++ b/ngboost/distns/distn.py
@@ -1,4 +1,5 @@
 import numpy as np
+from warnings import warn
 
 class Distn(object):
 	"""
@@ -28,10 +29,14 @@ def manifold(Score, Distribution):
 	it also carries the appropriate `total_score` and `grad` methods that are inherited through 
 	distribution-specific inheritence of the relevant implementation of the scoring rule
 	"""
-	try:
-		DistScore = {S.__base__:S for S in Distribution.scores}[Score]
-	except KeyError as err:
-		raise ValueError(f'''The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.''') from err
+	if Score in Distribution.scores:
+		DistScore = Score
+		warn(f'Using Dist={Score.__name__} is unnecessary. NGBoost automatically selects the correct implementation when LogScore or CRPScore is used')
+	else:
+		try:
+			DistScore = {S.__base__:S for S in Distribution.scores}[Score]
+		except KeyError as err:
+			raise ValueError(f'The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.') from err
 
 	class Manifold(DistScore, Distribution):
 		pass

--- a/ngboost/distns/distn.py
+++ b/ngboost/distns/distn.py
@@ -26,14 +26,13 @@ def manifold(Score, Distribution):
 	(thus the name of the function). The resulting object has all the parameters of the distribution 
 	can be sliced and indexed like one, and carries the distributions `fit` and `sample` methods, but 
 	it also carries the appropriate `total_score` and `grad` methods that are inherited through 
-	distribution-specific inheritence of the relevant implementation of the scoring rule.
+	distribution-specific inheritence of the relevant implementation of the scoring rule
 	"""
-   
-    try:
-        DistScore = {S.__base__:S for S in Distribution.scores}[Score]
-    except KeyError as err:
-        raise ValueError(f'''The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.''') from err
-        
-    class Manifold(DistScore, Distribution):
-        pass    
-    return Manifold
+	try:
+		DistScore = {S.__base__:S for S in Distribution.scores}[Score]
+	except KeyError as err:
+		raise ValueError(f'''The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.''') from err
+
+	class Manifold(DistScore, Distribution):
+		pass
+	return Manifold

--- a/ngboost/distns/distn.py
+++ b/ngboost/distns/distn.py
@@ -20,24 +20,11 @@ class Distn(object):
 
 	def __len__(self):
 		return self._params.shape[1]
-		
-def manifold(Score, Distribution):
-	"""
-	Mixes a scoring rule and a distribution together to create the resultant "Reimannian Manifold"
-	(thus the name of the function). The resulting object has all the parameters of the distribution 
-	can be sliced and indexed like one, and carries the distributions `fit` and `sample` methods, but 
-	it also carries the appropriate `total_score` and `grad` methods that are inherited through 
-	distribution-specific inheritence of the relevant implementation of the scoring rule
-	"""
-	if Score in Distribution.scores:
-		DistScore = Score
-		warn(f'Using Dist={Score.__name__} is unnecessary. NGBoost automatically selects the correct implementation when LogScore or CRPScore is used')
-	else:
-		try:
-			DistScore = {S.__base__:S for S in Distribution.scores}[Score]
-		except KeyError as err:
-			raise ValueError(f'The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.') from err
 
-	class Manifold(DistScore, Distribution):
-		pass
-	return Manifold
+class RegressionDistn(Distn):
+	def predict(self): # predictions for regression are typically conditional means
+		return self.mean()
+
+class ClassificationDistn(Distn):
+	def predict(self): # returns class assignments
+		return np.argmax(self.class_probs(), 1)

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -1,4 +1,4 @@
-from ngboost.distns import Distn
+from ngboost.distns import RegressionDistn
 from ngboost.scores import LogScore, CRPScore
 import scipy as sp
 import numpy as np
@@ -40,10 +40,9 @@ class NormalCRPScore(CRPScore):
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
-class Normal(Distn):
+class Normal(RegressionDistn):
 
     n_params = 2
-    problem_type = "regression"
     scores = [NormalLogScore, NormalCRPScore]
 
     def __init__(self, params):
@@ -53,21 +52,21 @@ class Normal(Distn):
         self.var = self.scale ** 2
         self.dist = dist(loc=self.loc, scale=self.scale)
 
-    def __getattr__(self, name):
-        if name in dir(self.dist):
-            return getattr(self.dist, name)
-        return None
-
-    @property
-    def params(self):
-        return {'loc':self.loc, 'scale':self.scale}
-
     def fit(Y):
         m, s = sp.stats.norm.fit(Y)
         return np.array([m, np.log(s)])
 
     def sample(self, m):
         return np.array([self.rvs() for i in range(m)])
+    
+    def __getattr__(self, name): # gives us Normal.mean() required for RegressionDist.predict()
+        if name in dir(self.dist):
+            return getattr(self.dist, name)
+        return None
+    
+    @property
+    def params(self):
+        return {'loc':self.loc, 'scale':self.scale}
 
 ### Fixed Variance Normal ###
 class NormalFixedVarLogScore(NormalLogScore):

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -1,11 +1,10 @@
 from ngboost.distns import Distn
-from ngboost import LogScore, CRPScore
+from ngboost.scores import LogScore, CRPScore
 import scipy as sp
 import numpy as np
 from scipy.stats import norm as dist
 
 class NormalLogScore(LogScore):
-            # log score methods
     def score(self, Y):
         return -self.dist.logpdf(Y)
 
@@ -41,10 +40,11 @@ class NormalCRPScore(CRPScore):
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
-class Normal(Score, Distn):
+class Normal(Distn):
 
     n_params = 2
     problem_type = "regression"
+    scores = [NormalLogScore, NormalCRPScore]
 
     def __init__(self, params):
         super().__init__(params)
@@ -69,15 +69,7 @@ class Normal(Score, Distn):
     def sample(self, m):
         return np.array([self.rvs() for i in range(m)])
 
-# def Normal(score_name):
-#     Score = {'LogScore':NormalLogScore,
-#              'CRPScore':NormalCRPS}[score_name]
-    # could make a class method of Distn, e.g. Distn.get_score(score, dict) to check score is implemented
-
-
-
 ### Fixed Variance Normal ###
-
 class NormalFixedVarLogScore(NormalLogScore):
     def d_score(self, Y):
         D = np.zeros((len(Y), 1))
@@ -102,12 +94,10 @@ class NormalFixedVarCRPScore(NormalCRPScore):
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
-# def NormalFixedVar(score_name):
-#     Score = {'LogScore':NormalFixedVarLogScore,
-#              'CRPScore':NormalFixedVarCRPScore}[score_name]
 class NormalFixedVar(Normal):
 
     n_params = 1
+    scores = [NormalFixedVarLogScore, NormalFixedVarCRPScore]
 
     def __init__(self, params):
         self.loc = params[0]

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -1,10 +1,47 @@
 from ngboost.distns import Distn
+from ngboost import LogScore, CRPScore
 import scipy as sp
 import numpy as np
 from scipy.stats import norm as dist
 
+class NormalLogScore(LogScore):
+            # log score methods
+    def score(self, Y):
+        return -self.dist.logpdf(Y)
 
-class Normal(Distn):
+    def d_score(self, Y):
+        D = np.zeros((len(Y), 2))
+        D[:, 0] = (self.loc - Y) / self.var
+        D[:, 1] = 1 - ((self.loc - Y) ** 2) / self.var
+        return D
+
+    def metric(self):
+        FI = np.zeros((self.var.shape[0], 2, 2))
+        FI[:, 0, 0] = 1 / self.var + 1e-5
+        FI[:, 1, 1] = 2
+        return FI
+
+class NormalCRPScore(CRPScore):
+    def score(self, Y):
+        Z = (Y - self.loc) / self.scale
+        return (self.scale * (Z * (2 * sp.stats.norm.cdf(Z) - 1) + \
+                2 * sp.stats.norm.pdf(Z) - 1 / np.sqrt(np.pi)))
+
+    def d_score(self, Y):
+        Z = (Y - self.loc) / self.scale
+        D = np.zeros((len(Y), 2))
+        D[:, 0] = -(2 * sp.stats.norm.cdf(Z) - 1)
+        D[:, 1] = self.crps(Y) + (Y - self.loc) * D[:, 0]
+        return D
+
+    def metric(self):
+        I = np.c_[2 * np.ones_like(self.var), np.zeros_like(self.var),
+                  np.zeros_like(self.var), self.var]
+        I = I.reshape((self.var.shape[0], 2, 2))
+        I = 1 / (2 * np.sqrt(np.pi)) * I
+        return I
+
+class Normal(Score, Distn):
 
     n_params = 2
     problem_type = "regression"
@@ -32,42 +69,42 @@ class Normal(Distn):
     def sample(self, m):
         return np.array([self.rvs() for i in range(m)])
 
-    # log score methods
-    def nll(self, Y):
-        return -self.dist.logpdf(Y)
+# def Normal(score_name):
+#     Score = {'LogScore':NormalLogScore,
+#              'CRPScore':NormalCRPS}[score_name]
+    # could make a class method of Distn, e.g. Distn.get_score(score, dict) to check score is implemented
 
-    def D_nll(self, Y):
-        D = np.zeros((len(Y), 2))
+
+
+### Fixed Variance Normal ###
+
+class NormalFixedVarLogScore(NormalLogScore):
+    def d_score(self, Y):
+        D = np.zeros((len(Y), 1))
         D[:, 0] = (self.loc - Y) / self.var
-        D[:, 1] = 1 - ((self.loc - Y) ** 2) / self.var
         return D
 
-    def fisher_info(self):
-        FI = np.zeros((self.var.shape[0], 2, 2))
+    def metric(self):
+        FI = np.zeros((self.var.shape[0], 1, 1))
         FI[:, 0, 0] = 1 / self.var + 1e-5
-        FI[:, 1, 1] = 2
         return FI
 
-    # crps score methods
-    def crps(self, Y):
+class NormalFixedVarCRPScore(NormalCRPScore):
+    def d_score(self, Y):
         Z = (Y - self.loc) / self.scale
-        return (self.scale * (Z * (2 * sp.stats.norm.cdf(Z) - 1) + \
-                2 * sp.stats.norm.pdf(Z) - 1 / np.sqrt(np.pi)))
-
-    def D_crps(self, Y):
-        Z = (Y - self.loc) / self.scale
-        D = np.zeros((len(Y), 2))
+        D = np.zeros((len(Y), 1))
         D[:, 0] = -(2 * sp.stats.norm.cdf(Z) - 1)
-        D[:, 1] = self.crps(Y) + (Y - self.loc) * D[:, 0]
         return D
 
-    def crps_metric(self):
-        I = np.c_[2 * np.ones_like(self.var), np.zeros_like(self.var),
-                  np.zeros_like(self.var), self.var]
-        I = I.reshape((self.var.shape[0], 2, 2))
+    def metric(self): 
+        I = np.c_[2 * np.ones_like(self.var)]
+        I = I.reshape((self.var.shape[0], 1, 1))
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
+# def NormalFixedVar(score_name):
+#     Score = {'LogScore':NormalFixedVarLogScore,
+#              'CRPScore':NormalFixedVarCRPScore}[score_name]
 class NormalFixedVar(Normal):
 
     n_params = 1
@@ -82,27 +119,3 @@ class NormalFixedVar(Normal):
     def fit(Y):
         m, s = sp.stats.norm.fit(Y)
         return m
-
-    # log score methods
-    def D_nll(self, Y):
-        D = np.zeros((len(Y), 1))
-        D[:, 0] = (self.loc - Y) / self.var
-        return D
-
-    def fisher_info(self):
-        FI = np.zeros((self.var.shape[0], 1, 1))
-        FI[:, 0, 0] = 1 / self.var + 1e-5
-        return FI
-
-    # crps methods
-    def D_crps(self, Y):
-        Z = (Y - self.loc) / self.scale
-        D = np.zeros((len(Y), 1))
-        D[:, 0] = -(2 * sp.stats.norm.cdf(Z) - 1)
-        return D
-
-    def crps_metric(self): 
-        I = np.c_[2 * np.ones_like(self.var)]
-        I = I.reshape((self.var.shape[0], 1, 1))
-        I = 1 / (2 * np.sqrt(np.pi)) * I
-        return I

--- a/ngboost/manifold.py
+++ b/ngboost/manifold.py
@@ -1,0 +1,20 @@
+def manifold(Score, Distribution):
+	"""
+	Mixes a scoring rule and a distribution together to create the resultant "Reimannian Manifold"
+	(thus the name of the function). The resulting object has all the parameters of the distribution 
+	can be sliced and indexed like one, and carries the distributions `fit` and `sample` methods, but 
+	it also carries the appropriate `total_score` and `grad` methods that are inherited through 
+	distribution-specific inheritence of the relevant implementation of the scoring rule
+	"""
+	if Score in Distribution.scores:
+		DistScore = Score
+		warn(f'Using Dist={Score.__name__} is unnecessary. NGBoost automatically selects the correct implementation when LogScore or CRPScore is used')
+	else:
+		try:
+			DistScore = {S.__base__:S for S in Distribution.scores}[Score]
+		except KeyError as err:
+			raise ValueError(f'The scoring rule {Score.__name__} is not implemented for the {Distribution.__name__} distribution.') from err
+
+	class Manifold(DistScore, Distribution):
+		pass
+	return Manifold

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy as sp
+from ngboost.scores import LogScore, CRPScore
 from ngboost.distns import manifold, Normal
-from ngboost.scores import MLE, CRPS
 from ngboost.learners import default_tree_learner, default_linear_learner
 from ngboost.distns.normal import Normal
 from sklearn.utils import check_random_state
@@ -20,7 +20,7 @@ class NGBoost(object):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
     """
-    def __init__(self, Dist=Normal, Score=MLE,
+    def __init__(self, Dist=Normal, Score=LogScore,
                  Base=default_tree_learner, natural_gradient=True,
                  n_estimators=500, learning_rate=0.01, minibatch_frac=1.0,
                  verbose=True, verbose_eval=100, tol=1e-4,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -1,9 +1,11 @@
 import numpy as np
 import scipy as sp
-from ngboost.scores import LogScore, CRPScore
-from ngboost.distns import manifold, Normal
+
+from ngboost.scores import LogScore
+from ngboost.distns import Normal
+from ngboost.manifold import manifold
 from ngboost.learners import default_tree_learner, default_linear_learner
-from ngboost.distns.normal import Normal
+
 from sklearn.utils import check_random_state
 from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
@@ -200,10 +202,10 @@ class NGBoost(object):
     # these methods won't work unless the model is either an NGBRegressor, NGBClassifier, or NGBSurvival object,
     # each of which have the dist_to_prediction() method defined in their own specific way
     def predict(self, X): 
-        return self.dist_to_prediction(self.pred_dist(X))
+        return self.pred_dist(X).predict()
 
     def staged_predict(self, X, max_iter=None):
-        return [self.dist_to_prediction(dist) for dist in self.staged_pred_dist(X, max_iter=None)]
+        return [dist.predict() for dist in self.staged_pred_dist(X, max_iter=None)]
 
     def get_shap_tree_explainer(self, param_idx=0, **kwargs):
         """

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy as sp
-from ngboost.distns import Normal
+from ngboost.distns import manifold, Normal
 from ngboost.scores import MLE, CRPS
 from ngboost.learners import default_tree_learner, default_linear_learner
 from ngboost.distns.normal import Normal
@@ -28,6 +28,7 @@ class NGBoost(object):
         self.Dist = Dist
         self.Score = Score
         self.Base = Base
+        self.Manifold = manifold(Score, Dist)
         self.natural_gradient = natural_gradient
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -172,7 +172,7 @@ class NGBoost(object):
         return self
 
     def score(self, X, Y):
-        return self.pred_dist(X).total_score(Y)
+        return self.Manifold(self.pred_dist(X).params_).total_score(Y)
 
     def pred_dist(self, X, max_iter=None):
         if max_iter is not None: # get prediction at a particular iteration if asked for
@@ -181,7 +181,7 @@ class NGBoost(object):
             dist = self.staged_pred_dist(X, max_iter=self.best_val_loss_itr)[-1]
         else: 
             params = np.asarray(self.pred_param(X, max_iter))
-            dist = self.Manifold(params.T)
+            dist = self.Dist(params.T)
         return dist
 
     def staged_pred_dist(self, X, max_iter=None):
@@ -191,7 +191,7 @@ class NGBoost(object):
         for i, (models, s) in enumerate(zip(self.base_models, self.scalings)):
             resids = np.array([model.predict(X) for model in models]).T
             params -= self.learning_rate * resids * s
-            dists = self.Manifold(np.copy(params.T)) # if the params aren't copied, param changes with stages carry over to dists
+            dists = self.Dist(np.copy(params.T)) # if the params aren't copied, param changes with stages carry over to dists
             predictions.append(dists)
             if max_iter and i == max_iter:
                 break

--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -4,20 +4,20 @@ class Score():
     def total_score(self, Y, sample_weight=None):
         return np.average(self.score(Y.squeeze()), weights=sample_weight)
 
-    def grad(Y, natural=True):
+    def grad(self, Y, natural=True):
         grad = self.d_score(Y)
         if natural:
             metric = self.metric()
             grad = np.linalg.solve(metric, grad)
         return grad
 
-class LogScore(ScoringRule):
+class LogScore(Score):
     def metric(self, n_mc_samples=100):
         grads = np.stack([self.d_score(Y) for Y in self.sample(n_mc_samples)])
         return np.mean(np.einsum('sik,sij->sijk', grads, grads), axis=0)
     # autofit method from d_score?
 MLE = LogScore
 
-class CRPScore(ScoringRule):
+class CRPScore(Score):
     pass
 CRPS = CRPScore


### PR DESCRIPTION
Here’s a summary of the refactor:

For distributions, the top level class is `Distn`, which implements default methods for slicing and indexing. This class has two subclasses: `RegressionDistn` and `ClassificationDistn`, which implement the appropriate methods for prediction (mean for regression, mode for classification). Each distribution (e.g. `Normal`) is a subclass of one of these two classes. Each distribution implements the parameters of that distribution as well as methods for fitting the marginal and sampling. All `RegressionDistn`s must additionally implement `mean()` and `ClassificationDistn`s must implement `class_probs()`.

The most specific scoring rule is a “distribution score” (e.g. `NormalLogScore`), which typically implements `score()`, `d_score()`, and `metric()` methods for some combination of scoring rule and distribution. Each distribution score is a subclass of a kind of score (e.g. `LogScore`). `CRPScore` has no additional functionality at the moment, but `LogScore` implements a default method for calculating the metric (via MC fisher) using just the `d_score()` implementation of the distribution-specific classes. Thus any distribution score that is a subclass of `LogScore` does not need to implement `metric`, although it would increase speed. The two types of scores are subclasses of `Score`, which implements methods for `total_score()` (weighted average of the `score()` from the distribution score) and `grad()` (inverse Riemannian metric times gradient).

The NGBoost core code now uses a function `manifold()` to combine the user-specified scoring rule and distribution. `manifold()` implements a dynamic mix-in which looks up the appropriate implementation (subclass) of the scoring rule (the one for the specified distribution) and dynamically generates a new class that mixes in all of those methods with those of the distribution. The result, which I call a “manifold” (since a Riemannian manifold is a distribution space plus a metric) is a class that holds all the distributional properties, but is also endowed with methods to calculate the appropriate metrics and gradients. The NGBoost core code has been slightly modified to work directly with manifold objects constructed from a score and distribution instead of with the raw score and distribution classes.

To summarize:
```
           < distribution < disttype < Distn
manifold < 
           < distributionscore < score < Score
```

And, for a concrete example:
```
                    < Normal < RegressionDistn <Distn
NormalLogManifold < 
                    < NormalLogScore < LogScore < Score  
```
although note that you will find no `NormalLogManifold` class in the code- it gets generated dynamically when the user inputs `Dist=Normal` and `Score=LogScore`.

The upshot of all of this is that methods are all implemented (once) at the correct level of generality a) with clearer naming and b) with clearer encapsulation of related methods and concepts and c) with less repetition. 

As far as the user is concerned, there is no change. `pred_dist()` still returns distribution objects, which now do not have the score, derivative, and metric methods attached to them.