### PR TITLE
Dataframe compatibility for inputs for fit and predict functions

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -11,6 +11,7 @@ from ngboost.learners import default_tree_learner
 from ngboost.ngboost import NGBoost
 from ngboost.scores import LogScore
 from sklearn.base import BaseEstimator
+from sklearn.utils import check_array
 
 
 class NGBRegressor(NGBoost, BaseEstimator):
@@ -252,12 +253,18 @@ class NGBSurvival(NGBoost, BaseEstimator):
         Fits an NGBoost survival model to the data. For additional parameters see ngboost.NGboost.fit
 
         Parameters:
-            X                       : numpy array of predictors (n x p)
-            T                       : numpy array of times to event or censoring (n). Should be floats 
-            E                       : numpy array of event indicators (n). E[i] = 1 <=> T[i] is the time of an event, else censoring time
-            T_val                   : validation-set times, if any
-            E_val                   : validation-set event idicators, if any
+            X                       : DataFrame object or List or numpy array of predictors (n x p) in Numeric format
+            T                       : DataFrame object or List or numpy array of times to event or censoring (n). Should be floats 
+            E                       : DataFrame object or List or numpy array of event indicators (n). E[i] = 1 <=> T[i] is the time of an event, else censoring time
+            T_val                   : DataFrame object or List or validation-set times, in Numeric format if any
+            E_val                   : DataFrame object or List or validation-set event idicators, in Numeric format if any
         """
+        
+        X = check_array(X)
+        
+        if X_val is not None:
+            X_val = check_array(X_val)
+        
         return super().fit(
             X,
             Y_from_censored(T, E),

--- a/ngboost/helpers.py
+++ b/ngboost/helpers.py
@@ -1,9 +1,12 @@
 import numpy as np
-
+from sklearn.utils import check_array
 
 def Y_from_censored(T, E=None):
     if T is None:
         return None
+    else:
+        T = check_array(T,ensure_2d=False)
+        T=T.reshape(T.shape[0])
     if T.dtype == [
         ("Event", "?"),
         ("Time", "<f8"),
@@ -11,6 +14,9 @@ def Y_from_censored(T, E=None):
         return T
     if E is None:
         E = np.ones_like(T)
+    else:
+        E = check_array(E,ensure_2d=False)
+        E = E.reshape(E.shape[0])
     Y = np.empty(dtype=[("Event", np.bool), ("Time", np.float64)], shape=T.shape[0])
     Y["Event"] = E.astype(np.bool)
     Y["Time"] = T.astype(np.float64)

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -6,7 +6,7 @@ from ngboost.distns import Normal, k_categorical
 from ngboost.manifold import manifold
 from ngboost.learners import default_tree_learner, default_linear_learner
 
-from sklearn.utils import check_random_state
+from sklearn.utils import check_random_state,check_X_y,check_array
 from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 
@@ -185,10 +185,10 @@ class NGBoost(object):
         Fits an NGBoost model to the data
 
         Parameters:
-            X                       : numpy array of predictors (n x p)
-            Y                       : numpy array of outcomes (n). Should be floats for regression and integers from 0 to K-1 for K-class classification
-            X_val                   : validation-set predictors, if any
-            Y_val                   : validation-set outcomes, if any
+            X                       : DataFrame object or List or numpy array of predictors (n x p) in Numeric format
+            Y                       : DataFrame object or List or numpy array of outcomes (n) in Numeric format. Should be floats for regression and integers from 0 to K-1 for K-class classification
+            X_val                   : DataFrame object or List or numpy array of validation-set predictors in Numeric format, if any
+            Y_val                   : DataFrame object or List or numpy array of validation-set outcomes in Numeric format, if any
             sample_weight           : how much to weigh each example in the training set. numpy array of size (n) (defaults to 1)
             val_sample_weight       : how much to weigh each example in the validation set. (defaults to 1)
             train_loss_monitor      : a custom score or set of scores to track on the training set during training. Defaults to the score defined in the NGBoost constructor
@@ -198,12 +198,18 @@ class NGBoost(object):
         Output:
             A fit NGBRegressor object
         """
-
+        
+        if y is None:
+            raise ValueError("y cannot be None")
+        
+        X, Y = check_X_y(X, Y, y_numeric=True)
+        
         loss_list = []
         self.fit_init_params_to_marginal(Y)
 
         params = self.pred_param(X)
         if X_val is not None and Y_val is not None:
+            X_val, Y_val = check_X_y(X_val, Y_val, y_numeric=True)
             val_params = self.pred_param(X_val)
             val_loss_list = []
             best_val_loss = np.inf
@@ -296,12 +302,15 @@ class NGBoost(object):
         Predict the conditional distribution of Y at the points X=x
 
         Parameters:
-            X        : numpy array of predictors (n x p)
+            X        : DataFrame object or List or numpy array of predictors (n x p) in Numeric Format
             max_iter : get the prediction at the specified number of boosting iterations
 
         Output:
             A NGBoost distribution object
         """
+        
+        X = check_array(X)
+        
         if (
             max_iter is not None
         ):  # get prediction at a particular iteration if asked for
@@ -343,12 +352,15 @@ class NGBoost(object):
         Point prediction of Y at the points X=x
 
         Parameters:
-            X        : numpy array of predictors (n x p)
+            X        : DataFrame object or List or numpy array of predictors (n x p) in Numeric Format
             max_iter : get the prediction at the specified number of boosting iterations
 
         Output:
             Numpy array of the estimates of Y
         """
+        
+        X = check_array(X)
+        
         return self.pred_dist(X, max_iter=max_iter).predict()
 
     def staged_predict(self, X, max_iter=None):

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -199,7 +199,7 @@ class NGBoost(object):
             A fit NGBRegressor object
         """
         
-        if y is None:
+        if Y is None:
             raise ValueError("y cannot be None")
         
         X, Y = check_X_y(X, Y, y_numeric=True)


### PR DESCRIPTION
This is for changes discussed in https://github.com/stanfordmlgroup/ngboost/pull/128

Changes Implemented:

used sklearn functions to validate user inputs for support of pandas dataframe , list, or arrays.

There are also validations for strings or null values which are prohibited
