### PR TITLE
Update setup py 3

### DIFF
--- a/ngboost/version.py
+++ b/ngboost/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.3dev"
+__version__ = "0.2.4dev"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
 import setuptools
+import sys
 
+
+assert sys.version_info >= (3, 6, 0), "NGBoost requires Python 3.6+"
 
 def get_version() -> str:
     version_filepath = os.path.join(os.path.dirname(__file__), "ngboost", "version.py")
@@ -27,6 +30,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/stanfordmlgroup/ngboost",
     license="Apache License 2.0",
+    python_requires=">=3.6",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 
 assert sys.version_info >= (3, 6, 0), "NGBoost requires Python 3.6+"
 
+
 def get_version() -> str:
     version_filepath = os.path.join(os.path.dirname(__file__), "ngboost", "version.py")
     with open(version_filepath) as f:


### PR DESCRIPTION
Closes https://github.com/stanfordmlgroup/ngboost/issues/164

This update will create an obvious failure when installing on unsupported versions.

