### PR TITLE
Fix Laplace docs and add Laplace distribution.

### DIFF
--- a/docs/5-dev.html
+++ b/docs/5-dev.html
@@ -26,8 +26,8 @@
   "@type": "NewsArticle",
   "mainEntityOfPage": "https://stanfordmlgroup.github.io/ngboost/5-dev.html",
   "headline": "Developing NGBoost",
-  "datePublished": "2020-03-31T11:59:13-07:00",
-  "dateModified": "2020-03-31T11:59:13-07:00",
+  "datePublished": "2020-07-10T11:03:21-07:00",
+  "dateModified": "2020-07-10T11:03:21-07:00",
   "description": "        Developing NGBoost    As you work with NGBoost, you may want to experiment with distributions or scores that are not yet supported. Here we will walk...",
   "author": {
     "@type": "Person",

--- a/examples/user-guide/content/5-dev.ipynb
+++ b/examples/user-guide/content/5-dev.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,8 +127,8 @@
     "\n",
     "    def d_score(self, Y):\n",
     "        D = np.zeros((len(Y), 2)) # first col is dS/d𝜇, second col is dS/d(log(b))\n",
-    "        D[:, 0] = np.sign(self.logscale - Y)/self.scale\n",
-    "        D[:, 1] = 1 - np.abs(self.logscale - Y)/self.scale\n",
+    "        D[:, 0] = np.sign(self.loc - Y)/self.scale\n",
+    "        D[:, 1] = 1 - np.abs(self.loc - Y)/self.scale\n",
     "        return D"
    ]
   },
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,8 +173,8 @@
     "\n",
     "    def d_score(self, Y):\n",
     "        D = np.zeros((len(Y), 2)) # first col is dS/d𝜇, second col is dS/d(log(b))\n",
-    "        D[:, 0] = -np.sign(self.logscale - Y)/self.scale\n",
-    "        D[:, 1] = 1 - np.abs(self.logscale - Y)/self.scale\n",
+    "        D[:, 0] = np.sign(self.loc - Y)/self.scale\n",
+    "        D[:, 1] = 1 - np.abs(self.loc - Y)/self.scale\n",
     "        return D\n",
     "\n",
     "class Laplace(RegressionDistn):\n",
@@ -218,20 +218,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[iter 0] loss=3.5592 val_loss=0.0000 scale=0.5000 norm=5.1998\n",
-      "[iter 100] loss=3.3162 val_loss=0.0000 scale=0.2500 norm=1.5259\n",
-      "[iter 200] loss=3.3106 val_loss=0.0000 scale=0.0312 norm=0.1790\n",
-      "[iter 300] loss=3.3104 val_loss=0.0000 scale=0.0000 norm=0.0001\n",
-      "[iter 400] loss=3.3104 val_loss=0.0000 scale=0.0000 norm=0.0001\n",
-      "Test MSE 61.24969569895786\n",
-      "Test NLL 3.2824343523391057\n"
+      "[iter 0] loss=3.5989 val_loss=0.0000 scale=1.0000 norm=6.8968\n",
+      "[iter 100] loss=2.8432 val_loss=0.0000 scale=1.0000 norm=5.3980\n",
+      "[iter 200] loss=2.4432 val_loss=0.0000 scale=1.0000 norm=3.5194\n",
+      "[iter 300] loss=2.2069 val_loss=0.0000 scale=1.0000 norm=2.4722\n",
+      "[iter 400] loss=2.0325 val_loss=0.0000 scale=1.0000 norm=1.9901\n",
+      "Test MSE 13.593387122611777\n",
+      "Test NLL 2.552651522788599\n"
      ]
     }
    ],
@@ -348,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/ngboost/distns/__init__.py
+++ b/ngboost/distns/__init__.py
@@ -1,6 +1,7 @@
 from .distn import RegressionDistn, ClassificationDistn
 from .normal import Normal, NormalFixedVar
 from .multivariate_normal import MultivariateNormal
+from .laplace import Laplace
 from .lognormal import LogNormal
 from .exponential import Exponential
 from .categorical import k_categorical, Bernoulli

--- a/ngboost/distns/laplace.py
+++ b/ngboost/distns/laplace.py
@@ -1,0 +1,68 @@
+import numpy as np
+from scipy.stats import laplace as dist
+from ngboost.distns.distn import RegressionDistn
+from ngboost.scores import LogScore, CRPScore
+
+
+class LaplaceLogScore(LogScore):
+    def score(self, Y):
+        return -self.dist.logpdf(Y)
+
+    def d_score(self, Y):
+        D = np.zeros((len(Y), 2))
+        D[:, 0] = np.sign(self.loc - Y)/self.scale
+        D[:, 1] = 1 - np.abs(self.loc - Y)/self.scale
+        return D
+
+    def metric(self):
+        FI = np.zeros((self.loc.shape[0], 2, 2))
+        FI[:, 0, 0] = 1 / self.scale ** 2
+        FI[:, 1, 1] = 1
+        return FI
+
+
+class LaplaceCRPScore(CRPScore):
+    def score(self, Y):
+        return np.abs(Y - self.loc) + np.exp(-np.abs(Y - self.loc) / self.scale) * self.scale - 0.75 * self.scale
+
+    def d_score(self, Y):
+        D = np.zeros((len(Y), 2))
+        D[:, 0] = np.sign(self.loc - Y) * (1 - np.exp(-np.abs(Y - self.loc) / self.scale))
+        D[:, 1] = np.exp(-np.abs(Y - self.loc) / self.scale) * (self.scale + np.abs(Y - self.loc))
+        return D
+
+    def metric(self):
+        FI = np.zeros((self.loc.shape[0], 2, 2))
+        FI[:, 0, 0] = 0.5 / self.scale
+        FI[:, 1, 1] = 0.25 * self.scale
+        return FI
+
+
+class Laplace(RegressionDistn):
+
+    n_params = 2
+    scores = [LaplaceLogScore, LaplaceCRPScore]
+
+    def __init__(self, params):
+        self._params = params
+        self.loc = params[0]
+        self.logscale = params[1]
+        self.scale = np.exp(params[1])
+        self.dist = dist(loc=self.loc, scale=self.scale)
+
+    def fit(Y):
+        m, s = dist.fit(Y)
+        return np.array([m, np.log(s)])
+
+    def sample(self, m):
+        return np.array([self.dist.rvs() for i in range(m)])
+
+    def __getattr__(self, name):
+        if name in dir(self.dist):
+            return getattr(self.dist, name)
+        return None
+
+    @property
+    def params(self):
+        return {'loc':self.loc, 'scale':self.scale}
+


### PR DESCRIPTION
This should fix #177 by addressing the documentation typo in log-likelihood gradient.

Moreover I realized we might as well add the complete Laplace distribution to the package. The implementation here supports both LogScore and CRPScore. 

For future reference I calculated the Fisher Information here as variance of the score, using the following Mathematica code.
```
Expectation[ (Abs[y-m]/b-1)^2,y \[Distributed] LaplaceDistribution[m,b]]
Expectation[-1/b Sign[m-y] (Abs[m-y]/b-1),y \[Distributed] LaplaceDistribution[m,b]] 
```

The CRPS for the Laplace is given in [[Jordan et al. 2019]](https://www.jstatsoft.org/index.php/jss/article/view/v090i12). 

<img width="721" alt="Screen Shot 2020-09-04 at 1 18 42 AM" src="https://user-images.githubusercontent.com/1163598/92217471-956b8c00-ee4c-11ea-8eed-943f7d7a13b8.png">

The information metric involved integrals calculated with the following Mathematica code:

```
Integrate[0.25 / b^2Exp[(y-m)/b]^2,{y,-Infinity,m}]
Integrate[0.25 / b^2Exp[(y-m)/b]^2(y-m),{y,-Infinity,m}]
Integrate[0.25 / b^2Exp[(y-m)/b]^2(y-m)^2,{y,-Infinity,m}]
Integrate[0.25 / b^2Exp[-(y-m)/b]^2,{y,m,Infinity}]
Integrate[0.25 / b^2Exp[-(y-m)/b]^2(y-m),{y,m,Infinity}]
Integrate[0.25 / b^2Exp[-(y-m)/b]^2(y-m)^2,{y,m,Infinity}]
```