### PR TITLE
Fix `make package` typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ install:
 	pip install poetry && poetry install
 
 package:
-	poetry package
+	poetry build
 
-publish:
+publish: package
 	poetry publish
 
 lint:


### PR DESCRIPTION
Sorry peeps! All good now:

```bash
~/code/misc/ngboost fix/makefile
ngboost ❯ make package
poetry build
Building ngboost (0.3.8dev)
  - Building sdist
  - Built ngboost-0.3.8.dev0.tar.gz
  - Building wheel
  - Built ngboost-0.3.8.dev0-py3-none-any.whl

~/code/misc/ngboost fix/makefile*
ngboost ❯ make publish
poetry build
Building ngboost (0.3.8dev)
  - Building sdist
  - Built ngboost-0.3.8.dev0.tar.gz
  - Building wheel
  - Built ngboost-0.3.8.dev0-py3-none-any.whl
poetry publish

Username: *****
Password: ******
```