### PR TITLE
Sympy

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ matplotlib
 nbinteract
 scipy
 jupyter-book
+sympy

--- a/ngboost/distns/__init__.py
+++ b/ngboost/distns/__init__.py
@@ -9,3 +9,4 @@ from .multivariate_normal import MultivariateNormal  # NOQA
 from .normal import Normal, NormalFixedVar  # NOQA
 from .poisson import Poisson  # NOQA
 from .t import T, TFixedDf, TFixedDfFixedVar  # NOQA
+from .gamma import Gamma

--- a/ngboost/distns/gamma.py
+++ b/ngboost/distns/gamma.py
@@ -1,0 +1,92 @@
+"""The NGBoost Gamma distribution and scores"""
+import numpy as np
+import scipy as sp
+from scipy.stats import gamma as dist
+from scipy.special import polygamma
+import numpy
+import math
+from ngboost.distns.distn import RegressionDistn
+from ngboost.scores import CRPScore, LogScore
+
+import sympy as sym
+from sympy import stats as symstats
+
+from sympy.printing.lambdarepr import NumPyPrinter
+from sympy.utilities.lambdify import lambdastr
+
+# Need to create str, because non-numpy functions are used: polygamma; and exp is not translated into numpy inside polygamma
+def newlambdify(args, funs):
+    funcstr = lambdastr(args, funs, printer=NumPyPrinter)
+    funcstr = funcstr.replace(
+        ' exp', 'numpy.exp'
+    )
+    return eval(funcstr)
+
+logk, logtheta, x = sym.symbols('logk logtheta x')
+
+distr = symstats.Gamma('dist', sym.exp(logk), sym.exp(logtheta))
+score = -sym.log(symstats.density( distr ).pdf(x))
+def neg_loglikelihood_sympy(mu, logsigma, x):
+    return -sym.log(symstats.density( symstats.Gamma('dist', sym.exp(logk), sym.exp(logtheta)) ).pdf(x))
+
+# Need to vectorize, because FI matrix is calculated by simulation, 
+# plus I guess polygamma doesn't support vector operations
+neg_loglikelihood = np.vectorize( newlambdify((logk, logtheta, x), neg_loglikelihood_sympy(logk, logtheta, x) ) )
+D_0 = np.vectorize( newlambdify( (logk, logtheta, x), sym.diff(neg_loglikelihood_sympy(logk, logtheta, x), logk) ) )
+D_1 = np.vectorize( newlambdify( (logk, logtheta, x), sym.diff(neg_loglikelihood_sympy(logk, logtheta, x), logtheta) ) )
+FI_0_0 = np.vectorize( newlambdify( (logk, logtheta), sym.factor(sym.expand(symstats.E(sym.factor(sym.expand(sym.diff(sym.diff(score, logk), logk))).subs(x, distr)))) ) )
+FI_0_1 = np.vectorize( newlambdify( (logk, logtheta), sym.factor(sym.expand(symstats.E(sym.factor(sym.expand(sym.diff(sym.diff(score, logk), logtheta))).subs(x, distr)))) ) )
+FI_1_0 = np.vectorize( newlambdify( (logk, logtheta), sym.factor(sym.expand(symstats.E(sym.factor(sym.expand(sym.diff(sym.diff(score, logtheta), logk))).subs(x, distr)))) ) )
+FI_1_1 = np.vectorize( newlambdify( (logk, logtheta), sym.factor(sym.expand(symstats.E(sym.factor(sym.expand(sym.diff(sym.diff(score, logtheta), logtheta))).subs(x, distr)))) ) )
+
+class GammaLogScore(LogScore):
+
+    def score(self, Y):
+        return -dist.logpdf(Y, self.a, loc=np.zeros_like(self.a), scale=self.scale)
+        # return neg_loglikelihood(k=self.a, logtheta=self.logscale, x=Y)
+
+    def d_score(self, Y):
+        D = np.zeros((len(Y), 2)) # first col is dS/da, second col is dS/d(log(scale))
+        D[:, 0] = D_0(logk=self.loga, logtheta=self.logscale, x=Y)
+        D[:, 1] = D_1(logk=self.loga, logtheta=self.logscale, x=Y)
+        return D
+    
+    # no closed form
+    # def metric(self):
+    #     FI = np.zeros((self.scale.shape[0], 2, 2))
+    #     FI[:, 0, 0] = FI_0_0(logk=self.loga, logtheta=self.logscale)
+    #     FI[:, 0, 1] = FI_0_1(logk=self.loga, logtheta=self.logscale)
+    #     FI[:, 1, 0] = FI_1_0(logk=self.loga, logtheta=self.logscale)
+    #     FI[:, 1, 1] = FI_1_1(logk=self.loga, logtheta=self.logscale)
+
+class Gamma(RegressionDistn):
+
+    n_params = 2
+    scores = [GammaLogScore]
+
+    def __init__(self, params):
+        # save the parameters
+        self._params = params
+
+        # create other objects that will be useful later
+        self.loga = params[0]
+        self.logscale = params[1]
+        self.a = np.exp(params[0])
+        self.scale = np.exp(params[1]) # since params[1] is log(scale)
+        self.dist = dist(a=self.a, loc=0, scale=self.scale)
+
+    def fit(Y):
+        a, loc, scale = dist.fit(Y) # use scipy's implementation
+        return np.array([np.log(a), np.log(scale)])
+
+    def sample(self, m):
+        return np.array([self.dist.rvs() for i in range(m)])
+
+    def __getattr__(self, name): # gives us access to Laplace.mean() required for RegressionDist.predict()
+        if name in dir(self.dist):
+            return getattr(self.dist, name)
+        return None
+
+    @property
+    def params(self):
+        return {'a':self.a, 'scale':self.scale}

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -16,7 +16,7 @@ def neg_loglikelihood_sympy(mu, logsigma, x):
 
 neg_loglikelihood = sym.lambdify((mu, logsigma, x), neg_loglikelihood_sympy(mu, logsigma, x), 'numpy')
 D_0 = sym.lambdify( (mu, logsigma, x), sym.diff(neg_loglikelihood_sympy(mu, logsigma, x), mu), 'numpy')
-d_1 = sym.lambdify( (mu, logsigma, x), sym.diff(neg_loglikelihood_sympy(mu, logsigma, x), logsigma), 'numpy')
+D_1 = sym.lambdify( (mu, logsigma, x), sym.diff(neg_loglikelihood_sympy(mu, logsigma, x), logsigma), 'numpy')
 
 class NormalLogScore(LogScore):
 
@@ -26,7 +26,7 @@ class NormalLogScore(LogScore):
     def d_score(self, Y):        
         D = np.zeros((len(Y), 2))
         D[:, 0] = D_0(mu=self.loc, logsigma=np.log(self.scale), x=Y)
-        D[:, 1] = d_1(mu=self.loc, logsigma=np.log(self.scale), x=Y)
+        D[:, 1] = D_1(mu=self.loc, logsigma=np.log(self.scale), x=Y)
         return D
 
     def metric(self):

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -8,7 +8,7 @@ from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils import check_array, check_random_state, check_X_y
 
-from ngboost.distns import Normal, k_categorical
+from ngboost.distns import *
 from ngboost.learners import default_tree_learner
 from ngboost.manifold import manifold
 from ngboost.scores import LogScore


### PR DESCRIPTION
Adding new distribution: Gamma
Plus providing 2 working examples with Sympy:
- a simple one, where the distribution, gradients and Fisher information matrix can be calculated in closed form (Normal distribution)
- a complicated one, where the Fisher information is not closed (metric is not implemented) and the gradients use non-numpy functions (polygamma => need to import separately and need to use the string version of the lambdify function)

This way the development can speed up significantly and a wider community can contribute.