### PR TITLE
supported version checking via ngboost.__version__

### DIFF
--- a/ngboost/__init__.py
+++ b/ngboost/__init__.py
@@ -1,3 +1,13 @@
 """The NGBoost Library"""
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    # before python 3.8
+    from importlib_metadata import version
+
 from .api import NGBClassifier, NGBRegressor, NGBSurvival  # NOQA
 from .ngboost import NGBoost  # NOQA
+
+
+__version__ = version(__name__)

--- a/ngboost/__init__.py
+++ b/ngboost/__init__.py
@@ -9,5 +9,4 @@ except ImportError:
 from .api import NGBClassifier, NGBRegressor, NGBSurvival  # NOQA
 from .ngboost import NGBoost  # NOQA
 
-
 __version__ = version(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ numpy = ">=1.17, <2.0"
 scipy = ">=1.3, <2.0"
 tqdm = ">=4.4, <5.0"
 lifelines = ">=0.25, <0.29"
+importlib-metadata = "^3.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,5 @@
+import ngboost
+
+
+def test_version():
+    assert isinstance(ngboost.__version__, str)


### PR DESCRIPTION
This PR enables
```
 python -c 'import ngboost; print(ngboost.__version__)'
0.3.8.dev0
```