### PR TITLE
Multivariate normal implementation

### DIFF
--- a/examples/multivariate_normal.py
+++ b/examples/multivariate_normal.py
@@ -1,0 +1,99 @@
+"""
+Example taken from Using Neural Networks to Model Conditional Multivariate Densities
+Peter Martin Williams 1996
+Replication of Figure 3.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import multivariate_normal
+
+from ngboost import NGBRegressor
+from ngboost.distns import MultivariateNormal
+
+
+def simulate_data(N=3000):
+    x = np.random.rand(N) * np.pi
+    x = np.sort(x)
+    means = np.zeros((N, 2))
+    means[:, 0] = np.sin(2.5 * x) * np.sin(1.5 * x)
+    means[:, 1] = np.cos(3.5 * x) * np.cos(0.5 * x)
+    cov = np.zeros((N, 2, 2))
+    cov[:, 0, 0] = 0.01 + 0.25 * (1 - np.sin(2.5 * x)) ** 2
+    cov[:, 1, 1] = 0.01 + 0.25 * (1 - np.cos(2.5 * x)) ** 2
+    corr = np.sin(2.5 * x) * np.cos(0.5 * x)
+    off_diag = corr * np.sqrt(cov[:, 0, 0] * cov[:, 1, 1])
+    cov[:, 0, 1] = off_diag
+    cov[:, 1, 0] = off_diag
+    scipy_dists = [
+        multivariate_normal(mean=means[i, :], cov=cov[i, :, :]) for i in range(N)
+    ]
+    rvs = np.array([dist.rvs(1) for dist in scipy_dists])
+    return x, rvs, scipy_dists
+
+
+def cov_to_sigma(cov_mat):
+    """
+    Parameters:
+        cov_mat: Nx2x2 numpy array
+    Returns:
+        sigma: (N,2) numpy array containing the variances
+        corr: (N,) numpy array the correlation [-1,1] extracted from cov_mat
+    """
+
+    sigma = np.sqrt(np.diagonal(cov_mat, axis1=1, axis2=2))
+    corr = cov_mat[:, 0, 1] / (sigma[:, 0] * sigma[:, 1])
+    return sigma, corr
+
+
+if __name__ == "__main__":
+
+    SEED = 12345
+    np.random.seed(SEED)
+    X, Y, true_dist = simulate_data()
+    X = X.reshape(-1, 1)
+    dist = MultivariateNormal(2)
+
+    data_figure, data_axs = plt.subplots()
+    data_axs.plot(X, Y[:, 0], label="Dim 1")
+    data_axs.plot(X, Y[:, 1], label="Dim 2")
+    data_axs.set_xlabel("X")
+    data_axs.set_ylabel("Y")
+    data_axs.set_title("Input Data")
+    data_axs.legend()
+    data_figure.show()
+
+    X_val, Y_val, _ = simulate_data(500)
+    X_val = X_val.reshape(-1, 1)
+    ngb = NGBRegressor(
+        Dist=dist, verbose=True, n_estimators=2000, natural_gradient=True
+    )
+    ngb.fit(X, Y, X_val=X_val, Y_val=Y_val, early_stopping_rounds=100)
+    y_dist = ngb.pred_dist(X, max_iter=ngb.best_val_loss_itr)
+
+    # Extract parameters for plotting
+    mean = y_dist.mean()
+    sigma, corrs = cov_to_sigma(y_dist.cov)
+    true_cov_mat = np.array([dist.cov for dist in true_dist])
+    true_mean = np.array([dist.mean for dist in true_dist])
+    true_sigma, true_corrs = cov_to_sigma(true_cov_mat)
+
+    # Plot the parameters in the sigma, correlation representation
+    fig, axs = plt.subplots(5, 1, sharex=True)
+    colors = ["blue", "red"]
+    axs[4].set_xlabel("X")
+    for i in range(2):
+        axs[i].set_title("Mean Dimension:" + str(i))
+        axs[i].plot(X, mean[:, i], label="fitted")
+        axs[i].plot(X, true_mean[:, i], label="true")
+
+        axs[2 + i].set_title("Marginal Standard Deviation Dimension: " + str(i))
+        axs[2 + i].plot(X, sigma[:, i], label="fitted")
+        axs[2 + i].plot(X, true_sigma[:, i], label="true")
+    axs[4].set_title("Correlation")
+    axs[4].plot(X, corrs, label="fitted")
+    axs[4].plot(X, true_corrs, label="true")
+    for i in range(5):
+        axs[i].legend()
+    fig.tight_layout()
+    fig.show()

--- a/ngboost/distns/multivariate_normal.py
+++ b/ngboost/distns/multivariate_normal.py
@@ -5,7 +5,6 @@ Peter Martin Williams 1996
 """
 
 import numpy as np
-
 import scipy as sp
 
 from ngboost.distns.distn import RegressionDistn

--- a/ngboost/distns/multivariate_normal.py
+++ b/ngboost/distns/multivariate_normal.py
@@ -1,252 +1,294 @@
-"""The NGBoost multivariate Normal distribution and scores"""
-# pylint: disable=unused-argument,bare-except,too-many-locals
+"""
+parameterization and gradient equations inspiration
+taken from Using Neural Networks to Model Conditional Multivariate Densities
+Peter Martin Williams 1996
+"""
+
 import numpy as np
+
 import scipy as sp
-from scipy.stats import norm as dist
 
-eps = 1e-6
+from ngboost.distns.distn import RegressionDistn
+from ngboost.scores import LogScore
 
 
-class MultivariateNormal:  # pylint: disable=too-many-instance-attributes
-    # make n_params general
-    n_params = 5
+class MVNLogScore(LogScore):
+    def score(self, Y):
+        return -self.logpdf(Y)
 
-    def __init__(self, params, temp_scale=1.0):
-        self.n_params, self.N = params.shape
-        self.p = int(0.5 * (np.sqrt(8 * self.n_params + 9) - 3))
+    def d_score(self, Y):
+        """
+        Formulas for this part taken from the paper mentioned at the start
 
-        self.loc = params[: self.p, :].T
+        Args:
+            Y: The response data
 
-        self.L = np.zeros((self.p, self.p, self.N))
-        self.L[np.tril_indices(self.p)] = params[self.p :, :]
-        self.L = np.transpose(self.L, (2, 0, 1))
-        self.cov = self.L @ np.transpose(self.L, (0, 2, 1))
-        self.cov_inv = np.linalg.inv(self.cov)
-        self.dCovdL = self.D_cov_D_L()
+        Returns:
+            self.N, self.n_params shaped array containing the gradient.
 
-    def mean(self):
-        return np.exp(self.loc[:, 0])
+        """
+        diff, eta = self.summaries(Y)
 
-    def D_cov_D_L(self):
-        # create commutation matrix
-        commutation = np.zeros((self.p ** 2, self.p ** 2))
-        ind = np.arange(self.p ** 2).reshape(self.p, self.p).T.flatten()
-        commutation[np.arange(self.p ** 2), ind] = 1.0
+        gradient = np.zeros((self.N, self.n_params))
 
-        # compute Jacobian
-        dCovdL = (np.identity(self.p ** 2) + commutation) @ np.kron(
-            self.L, np.identity(self.p)
+        # Gradient of the mean
+        # N x 1 x p matrix by N x p x p
+        grad_mu = np.expand_dims(eta, 1) @ self.L.transpose(0, 2, 1)
+        grad_mu = grad_mu.squeeze()
+        gradient[:, : self.p] = grad_mu
+
+        # Gradient of the diagonal
+        diagonal_elements = np.diagonal(self.L, axis1=1, axis2=2)
+        grad_diag = (
+            diff * np.expand_dims(eta, 2) * np.expand_dims(diagonal_elements, 2) - 1
         )
-        dCovdL = dCovdL.reshape(-1, 2, 2, 2, 2).swapaxes(-2, -1)
-        return dCovdL
+        grad_diag = grad_diag.squeeze()
+        grad_reference = gradient[:, self.p :]
+        grad_reference[:, self.mask_diag] = grad_diag
 
-    def nll(self, Y):
-        try:
-            E = Y["Event"]
-            T = np.log(Y["Time"] + eps)
+        # Off diagonal elements of L gradient:
+        for par_idx in self.off_diags:
+            i = self.tril_indices[0][par_idx]
+            j = self.tril_indices[1][par_idx]
+            grad_reference[:, par_idx] = eta[:, j] * diff[:, i, 0]
 
-            (
-                mu0_given_1,
-                mu1_given_0,
-                var0_given_1,
-                var1_given_0,
-            ) = self.conditional_dist(T)
+        return gradient
 
-            cens = (1 - E) * (
-                dist.logpdf(T, loc=self.loc[:, 1], scale=self.cov[:, 1, 1] ** 0.5)
-                + np.log(
-                    eps + 1 - dist.cdf(T, loc=mu0_given_1, scale=var0_given_1 ** 0.5)
-                )
+    def metric(self):
+
+        """
+        Formulas for this part are not in the the paper mentioned.
+        Obtained by taking the expectation of the Hessian.
+
+
+        Returns:
+            self.N, self.n_params, self.n_params shaped array containing the fisher information for
+             the ith observation in the last two indices.
+
+        """
+        FisherInfo = np.stack([np.identity(self.n_params)] * self.N)
+        # FI of the location
+        FisherInfo[:, : self.p, : self.p] = self.L @ self.L.transpose(0, 2, 1)
+
+        # Get VarComp as a reference to the diagonals.
+        VarComp = FisherInfo[:, self.p :, self.p :]
+
+        # E[diff_i eta_j] is the following
+        cov_sum = self.L.transpose(0, 2, 1) @ self.cov
+
+        # Following loop is
+        # E[d^2l / dlog(a_ii) dlog(a_kk)]
+        # and
+        # E[d^2l / dlog(a_ii) dlog(a_kq)]
+        # where a_ik = exp(L_ki) if i=k and a_ik=L_ki otherwise.
+        for diag_idx in self.diags:
+            i = self.tril_indices[0][diag_idx]
+            value = (
+                self.L[:, i, i] * self.cov[:, i, i] * self.L[:, i, i]
+                + cov_sum[:, i, i] * self.L[:, i, i]
             )
-            uncens = E * (
-                dist.logpdf(T, loc=self.loc[:, 0], scale=self.cov[:, 0, 0] ** 0.5)
-                + np.log(
-                    eps + 1 - dist.cdf(T, loc=mu1_given_0, scale=var1_given_0 ** 0.5)
-                )
-            )
-            return -(cens + uncens)
-        except:  # NOQA
-            diff = Y - self.loc
-            M = diff[:, None, :] @ self.cov_inv @ diff[:, :, None]
-            half_log_det = np.log(eps + np.diagonal(self.L, axis1=1, axis2=2)).sum(-1)
-            const = self.p / 2 * np.log(eps + 2 * np.pi)
-            logpdf = -const - half_log_det - 0.5 * M.flatten()
-            return -logpdf
+            VarComp[:, diag_idx, diag_idx] = value
+            VarComp[:, diag_idx, diag_idx] = value
+            for par_idx in self.off_diags:
+                q = self.tril_indices[0][par_idx]
+                k = self.tril_indices[1][par_idx]
+                if i == k:
+                    value = self.cov[:, q, i] * self.L[:, i, i]
+                    VarComp[:, diag_idx, par_idx] = value
+                    VarComp[:, par_idx, diag_idx] = value
 
-    # pylint: disable=too-many-statements
-    def D_nll(self, Y_):
-        try:
-            E = Y_["Event"]
-            T = np.log(Y_["Time"] + eps)
+        # Off diagonals  w.r.t. off diagonals
+        for par_idx in self.off_diags:
+            j = self.tril_indices[0][par_idx]
+            i = self.tril_indices[1][par_idx]
+            for par_idx2 in self.off_diags:
+                k = self.tril_indices[0][par_idx2]
+                q = self.tril_indices[1][par_idx2]
+                if i == q:
+                    value = self.cov[:, k, j]
+                    VarComp[:, par_idx, par_idx2] = value
+                    VarComp[:, par_idx2, par_idx] = value
+        return FisherInfo
 
-            (
-                mu0_given_1,
-                mu1_given_0,
-                var0_given_1,
-                var1_given_0,
-            ) = self.conditional_dist(T)
-            mu0 = self.loc[:, 0]
-            mu1 = self.loc[:, 1]
-            var0 = self.cov[:, 0, 0]
-            var1 = self.cov[:, 1, 1]
-            cov = self.cov[:, 0, 1]
 
-            # reshape Jacobian
-            tril_indices = np.tril_indices(self.p)
-            J = self.dCovdL[:, :, :, tril_indices[0], tril_indices[1]]
-            J = np.transpose(J, (0, 3, 1, 2)).reshape(self.N, -1, self.p ** 2)
-            J = J.swapaxes(-2, -1)
+def get_chol_factor(lower_tri_vals):
+    """
 
-            # compute grad mu
-            D = np.zeros((self.N, self.n_params))
-            diff0 = T - mu0
-            diff1 = T - mu1
-            Z0 = diff0 / (var0 ** 0.5 + eps)
-            Z1 = diff1 / (var1 ** 0.5 + eps)
-            Z0_1 = (T - mu0_given_1) / (var0_given_1 ** 0.5 + eps)
-            Z1_0 = (T - mu1_given_0) / (var1_given_0 ** 0.5 + eps)
-            pdf0 = dist.pdf(T, loc=mu0_given_1, scale=var0_given_1 ** 0.5)
-            cdf0 = dist.cdf(T, loc=mu0_given_1, scale=var0_given_1 ** 0.5)
-            pdf1 = dist.pdf(T, loc=mu1_given_0, scale=var1_given_0 ** 0.5)
-            cdf1 = dist.cdf(T, loc=mu1_given_0, scale=var1_given_0 ** 0.5)
-            cens_mu0 = (1 - E) * (pdf0 / (eps + 1 - cdf0))
-            uncens_mu0 = E * (
-                diff0 / (eps + var0) - pdf1 / (eps + 1 - cdf1) * (cov / (eps + var0))
-            )
-            uncens_mu1 = E * (pdf1 / (eps + 1 - cdf1))
-            cens_mu1 = (1 - E) * (
-                diff1 / (eps + var1) - pdf0 / (eps + 1 - cdf0) * (cov / (eps + var1))
-            )
-            D[:, 0] = -(cens_mu0 + uncens_mu0)
-            D[:, 1] = -(cens_mu1 + uncens_mu1)
+    Args:
+        lower_tri_vals: numpy array, shaped as the number of lower triangular elements, number of observations.
+                        The values ordered according to np.tril_indices(p)
+                        where p is the dimension of the multivariate normal distn
 
-            # compute grad sigma
-            D_sigma = np.zeros((self.N, self.p ** 2))
+    Returns:
+        Nxpxp numpy array, with the lower triangle filled in. The diagonal is exponentiated.
 
-            cens_var0 = (1 - E) * (
-                pdf0 / (eps + 1 - cdf0) * Z0_1 / (eps + 2 * var0_given_1 ** 0.5)
-            )
-            uncens_var0 = E * (
-                0.5 * ((Z0 ** 2 - 1) / (eps + var0))
-                + pdf1
-                / (eps + 1 - cdf1)
-                * (
-                    -Z0 * (cov / (eps + var0 ** 1.5))
-                    + 0.5
-                    * Z1_0
-                    / (eps + var1_given_0 ** 0.5)
-                    * (cov / (eps + var0)) ** 2
-                )
-            )
-            D_sigma[:, 0] = -(cens_var0 + uncens_var0)
+    """
+    lower_size, N = lower_tri_vals.shape
 
-            uncens_var1 = E * (
-                pdf1 / (eps + 1 - cdf1) * Z1_0 / (eps + 2 * var1_given_0 ** 0.5)
-            )
-            cens_var1 = (1 - E) * (
-                0.5 * ((Z1 ** 2 - 1) / (eps + var1))
-                + pdf0
-                / (eps + 1 - cdf0)
-                * (
-                    -Z1 * (cov / (eps + var1 ** 1.5))
-                    + 0.5
-                    * Z0_1
-                    / (eps + var0_given_1 ** 0.5)
-                    * (cov / (eps + var1)) ** 2
-                )
-            )
-            D_sigma[:, 3] = -(cens_var1 + uncens_var1)
+    # solve p(p+3)/2 = lower_size to get the
+    # number of dimensions.
 
-            uncens_cov = E * (
-                pdf1
-                / (eps + 1 - cdf1)
-                * (
-                    Z0 / (eps + var0 ** 0.5)
-                    - Z1_0 / (eps + var1_given_0 ** 0.5) * (cov / (eps + var0))
-                )
-            )
-            cens_cov = (1 - E) * (
-                pdf0
-                / (eps + 1 - cdf0)
-                * (
-                    Z1 / (eps + var1 ** 0.5)
-                    - Z0_1 / (eps + var0_given_1 ** 0.5) * (cov / (eps + var1))
-                )
-            )
-            D_sigma[:, 1] = -(cens_cov + uncens_cov) * 0.5
-            D_sigma[:, 2] = -(cens_cov + uncens_cov) * 0.5
+    p = (-1 + (1 + 8 * lower_size) ** 0.5) / 2
+    p = int(p)
 
-            D_L = J.swapaxes(-2, -1) @ D_sigma[:, :, None]
-            D[:, self.p :] = D_L[..., 0]
+    if not isinstance(lower_tri_vals, np.ndarray):
+        lower_tri_vals = np.array(lower_tri_vals)
 
-            return D
+    L = np.zeros((N, p, p))
+    for par_ind, (k, l) in enumerate(zip(*np.tril_indices(p))):
+        if k == l:
+            # Add a small number to avoid singular matrices.
+            L[:, k, l] = np.exp(lower_tri_vals[par_ind, :]) + 1e-6
+        else:
+            L[:, k, l] = lower_tri_vals[par_ind, :]
+    return L
 
-        except:  # NOQA
-            # reshape Jacobian
-            tril_indices = np.tril_indices(self.p)
-            J = self.dCovdL[:, :, :, tril_indices[0], tril_indices[1]]
-            J = np.transpose(J, (0, 3, 1, 2)).reshape(self.N, -1, self.p ** 2)
-            J = J.swapaxes(-2, -1)
 
-            # compute grad mu
-            D = np.zeros((self.N, J.shape[-1] + self.p))
-            sigma_inv = np.linalg.inv(self.cov)
-            diff = self.loc - Y_
-            D[:, : self.p] = (sigma_inv @ diff[:, :, None])[..., 0]
+def MultivariateNormal(k):
+    #   """
+    #  Factory function that generates classes for k-dimensional multivariate normal distribution for NGBoost
 
-            # compute grad sigma
-            D_sigma = 0.5 * (
-                sigma_inv
-                - sigma_inv @ (diff[:, :, None] * diff[:, None, :]) @ sigma_inv
-            )
-            D_sigma = D_sigma.reshape(self.N, -1)
-            D_L = J.swapaxes(-2, -1) @ D_sigma[:, :, None]
-            D[:, self.p :] = D_L[..., 0]
+    # This distribution has LogScore implemented for it.
 
-            return D
+    # Currently only for a regression implementation.
+    # """
+    assert k >= 2, ValueError(
+        "Use k>=2 for MultivariateNormal."
+        "If k=1 use the ngboost.distns.Normal Distribution."
+    )
 
-    def fisher_info(self):
-        # reshape Jacobian
-        tril_indices = np.tril_indices(self.p)
-        J = self.dCovdL[:, :, :, tril_indices[0], tril_indices[1]]
+    class MVN(RegressionDistn):
+        """
+        Implementation of the Multivariate normal distribution for regression.
+        Using the parameterization Sigma^{-1} = LL^T and modelling L
+        diag(L) is exponentiated to ensure parameters are unconstrained.
 
-        FI = np.zeros((self.N, self.n_params, self.n_params))
+        Scipy's multivariate normal benchmarks were relatively
+        slow for pdf calculations so the implementation is from scratch.
 
-        # compute FI mu
-        FI[:, : self.p, : self.p] = self.cov_inv
+        As Scipy has considerably more features call self.scipy_distribution()
+        to return a list of distributions.
+        """
 
-        # compute FI sigma
-        M = np.einsum("nij,njkl->nikl", self.cov_inv, J)
-        M = np.einsum("nijx,njky->nikxy", M, M)
-        FI[:, self.p :, self.p :] = 0.5 * np.trace(M, axis1=1, axis2=2)
+        n_params = int(k * (k + 3) / 2)
+        scores = [MVNLogScore]
+        multi_output = True
 
-        return FI
+        # pylint: disable=super-init-not-called
+        def __init__(self, params):
+            super().__init__(params)
+            self.N = params.shape[1]
 
-    def conditional_dist(self, Y):
-        mu0 = self.loc[:, 0]
-        mu1 = self.loc[:, 1]
-        var0 = self.cov[:, 0, 0]
-        var1 = self.cov[:, 1, 1]
-        cov = self.cov[:, 0, 1]
+            # Number of MVN dimensions, =k originally
+            self.p = (-3 + (9 + 8 * self.n_params) ** 0.5) / 2
+            self.p = int(self.p)
 
-        mu0_given_1 = mu0 + cov * (1 / (eps + var1)) * (Y - mu1)
-        mu1_given_0 = mu1 + cov * (1 / (eps + var0)) * (Y - mu0)
-        var0_given_1 = var0 - cov * (1 / (eps + var1)) * cov
-        var1_given_0 = var1 - cov * (1 / (eps + var0)) * cov
+            # Extract parameters from params list
+            # Param array is assumed to of shape n_params,N
+            # First p rows are the mean
+            # rest are the lower triangle of L.
+            # Where Sigma_inverse = L@L.transpose()
+            # Diagonals modelled on the log scale.
+            self.loc = np.array(params[: self.p, :]).T
+            self.tril_L = np.array(params[self.p :, :])
 
-        return mu0_given_1, mu1_given_0, var0_given_1, var1_given_0
+            # Returns 3d array, shape (p, p, N)
+            self.L = get_chol_factor(self.tril_L)
 
-    def fit(Y):
-        try:
-            # place holder
-            m = np.array([8.0, 8.0])
-            sigma = np.array([[2.0, 1.0], [1.0, 2.0]])
-            L = sp.linalg.cholesky(sigma, lower=True)
-            return np.concatenate([m, L[np.tril_indices(2)]])
-        except:  # NOQA
+            # The following are useful for the Fisher Information operations
+            self.tril_indices = np.tril_indices(self.p)
+            self.mask_diag = self.tril_indices[0] == self.tril_indices[1]
+
+            self.off_diags = np.where(np.invert(self.mask_diag))[0]
+            self.diags = np.where(self.mask_diag)[0]
+
+            self.diag_incides_row = self.tril_indices[0][self.diags]
+            self.diag_incides_col = self.tril_indices[1][self.diags]
+
+            # The remainder is just for utility.
+            self.cov_inv = self.L @ self.L.transpose(0, 2, 1)
+
+            # Saving the pdf constant and means in an accessible format.
+            self.pdf_constant = -self.p / 2 * np.log(2 * np.pi)
+
+        def summaries(self, Y):
+            """
+            Parameters:
+                Y: The data being fit to
+
+            Returns:
+                diff: N x p x1 the residual between the mean and the data
+                eta: N x p which is L@diff
+            """
+            diff = np.expand_dims(self.loc - Y, 2)
+            eta = np.squeeze(np.matmul(self.L.transpose(0, 2, 1), diff))
+            return diff, eta
+
+        def logpdf(self, Y):
+            diff, eta = self.summaries(Y)
+            # the exponentiated part of the pdf:
+            p1 = -0.5 * np.sum(np.square(eta), axis=1)
+            p1 = p1.squeeze()
+            # this is the sqrt(determinant(Sigma) component of the pdf
+            p2 = np.sum(np.log(np.diagonal(self.L, axis1=1, axis2=2)), axis=1)
+
+            ret = p1 + p2 + self.pdf_constant
+            return ret
+
+        def fit(Y):
             N, p = Y.shape
             m = Y.mean(axis=0)  # pylint: disable=unexpected-keyword-arg
             diff = Y - m
             sigma = 1 / N * (diff[:, :, None] @ diff[:, None, :]).sum(0)
-            L = sp.linalg.cholesky(sigma, lower=True)
+            L = sp.linalg.cholesky(np.linalg.inv(sigma), lower=True)
+            diag_idx = np.diag_indices(p)
+            L[diag_idx] = np.log(L[diag_idx])
             return np.concatenate([m, L[np.tril_indices(p)]])
+
+        def rv(self):
+            # This is only useful for generating rvs so only compute it in rv.
+            if not hasattr(self, "L_cov"):
+                self.L_cov = np.linalg.cholesky(np.linalg.inv(self.cov_inv))
+
+            u = np.random.normal(loc=0, scale=1, size=(self.N, self.p, 1))
+            sample = np.expand_dims(self.loc, 2) + self.L_cov @ u
+            return np.squeeze(sample)
+
+        def rvs(self, n):
+            return [self.rv() for _ in range(n)]
+
+        def sample(self, n):
+            return self.rvs(n)
+
+        @property
+        def cov(self):
+            # Covariance matrix is for computing the fisher information
+            # If it is singular it is set an extremely large value. This likely won't affect anything.
+            # Could cov = ... inside the metric function but covariance
+            # is a useful quantity to return with predictions.
+            if not hasattr(self, "cov_mat"):
+                try:
+                    self.cov_mat = np.linalg.inv(self.cov_inv)
+                except np.linalg.LinAlgError:
+                    self.cov_mat = np.identity(self.p) * 1e20
+            return self.cov_mat
+
+        @property
+        def params(self):
+            return {"loc": self.loc, "scale": self.cov}
+
+        def scipy_distribution(self):
+            """
+            Returns:
+                List of scipy.stats.multivariate_normal distributions.
+            """
+            cov_mat = self.cov
+            return [
+                sp.stats.multivariate_normal(mean=self.loc[i, :], cov=cov_mat[i, :, :])
+                for i in range(self.N)
+            ]
+
+        def mean(self):
+            return self.loc
+
+    return MVN

--- a/ngboost/distns/multivariate_normal.py
+++ b/ngboost/distns/multivariate_normal.py
@@ -157,13 +157,14 @@ def get_chol_factor(lower_tri_vals):
 
 
 def MultivariateNormal(k):
-    #   """
-    #  Factory function that generates classes for k-dimensional multivariate normal distribution for NGBoost
+    """
+    #  Factory function that generates classes for
+    #  k-dimensional multivariate normal distributions for NGBoost
 
     # This distribution has LogScore implemented for it.
 
     # Currently only for a regression implementation.
-    # """
+    """
     assert k >= 2, ValueError(
         "Use k>=2 for MultivariateNormal."
         "If k=1 use the ngboost.distns.Normal Distribution."
@@ -202,7 +203,7 @@ def MultivariateNormal(k):
             # rest are the lower triangle of L.
             # Where Sigma_inverse = L@L.transpose()
             # Diagonals modelled on the log scale.
-            self.loc = np.array(params[: self.p, :]).T
+            self.loc = np.transpose(np.array(params[: self.p, :]))
             self.tril_L = np.array(params[self.p :, :])
 
             # Returns 3d array, shape (p, p, N)
@@ -271,7 +272,8 @@ def MultivariateNormal(k):
         @property
         def cov(self):
             # Covariance matrix is for computing the fisher information
-            # If it is singular it is set an extremely large value. This likely won't affect anything.
+            # If it is singular it is set an extremely large value.
+            # This will probably not affect anything.
             if self._cov_mat is None:
                 try:
                     self._cov_mat = np.linalg.inv(self.cov_inv)

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -8,7 +8,7 @@ from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils import check_array, check_random_state, check_X_y
 
-from ngboost.distns import Normal, k_categorical, MultivariateNormal
+from ngboost.distns import MultivariateNormal, Normal, k_categorical
 from ngboost.learners import default_tree_learner
 from ngboost.manifold import manifold
 from ngboost.scores import LogScore

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -8,7 +8,7 @@ from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils import check_array, check_random_state, check_X_y
 
-from ngboost.distns import Normal, k_categorical
+from ngboost.distns import Normal, k_categorical, MultivariateNormal
 from ngboost.learners import default_tree_learner
 from ngboost.manifold import manifold
 from ngboost.scores import LogScore
@@ -76,19 +76,31 @@ class NGBoost:
         self.tol = tol
         self.random_state = check_random_state(random_state)
         self.best_val_loss_itr = None
+        if hasattr(self.Dist, "multi_output"):
+            self.multi_output = self.Dist.multi_output
+        else:
+            self.multi_output = False
 
     def __getstate__(self):
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
         del state["Manifold"]
+        state["Dist_name"] = self.Dist.__name__
         if self.Dist.__name__ == "Categorical":
             del state["Dist"]
             state["K"] = self.Dist.n_params + 1
+        elif self.Dist.__name__ == "MVN":
+            del state["Dist"]
+            state["K"] = (-3 + (9 + 8 * (self.Dist.n_params)) ** 0.5) / 2
         return state
 
     def __setstate__(self, state_dict):
+        # Recreate the object which could not pickle
+        name_to_dist_dict = {"Categorical": k_categorical, "MVN": MultivariateNormal}
         if "K" in state_dict.keys():
-            state_dict["Dist"] = k_categorical(state_dict["K"])
+            state_dict["Dist"] = name_to_dist_dict[state_dict["Dist_name"]](
+                state_dict["K"]
+            )
         state_dict["Manifold"] = manifold(state_dict["Score"], state_dict["Dist"])
         self.__dict__ = state_dict
 
@@ -218,7 +230,7 @@ class NGBoost:
         if Y is None:
             raise ValueError("y cannot be None")
 
-        X, Y = check_X_y(X, Y, y_numeric=True)
+        X, Y = check_X_y(X, Y, y_numeric=True, multi_output=self.multi_output)
 
         self.n_features = X.shape[1]
 
@@ -227,7 +239,9 @@ class NGBoost:
 
         params = self.pred_param(X)
         if X_val is not None and Y_val is not None:
-            X_val, Y_val = check_X_y(X_val, Y_val, y_numeric=True)
+            X_val, Y_val = check_X_y(
+                X_val, Y_val, y_numeric=True, multi_output=self.multi_output
+            )
             val_params = self.pred_param(X_val)
             val_loss_list = []
             best_val_loss = np.inf

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -137,7 +137,7 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("k", [2, 3])
+@pytest.mark.parametrize("k", [1, 2, 3])
 @pytest.mark.parametrize(
     "learner",
     [
@@ -145,6 +145,8 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
         DecisionTreeRegressor(criterion="friedman_mse", max_depth=3),
     ],
 )
+# Ignore the k=1 warning
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_multivariatenormal(k: 2, learner):
     dist = MultivariateNormal(k)
 
@@ -165,7 +167,5 @@ def test_multivariatenormal(k: 2, learner):
     y_dist = ngb.pred_dist(X_test)
 
     mean = y_dist.mean
-    cmat = y_dist.cov
     sample = y_dist.rv()
-    params = y_dist.params
     scipy_list = y_dist.scipy_distribution()

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -134,10 +134,6 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
     y_prob = ngb.predict_proba(X_test)
     y_dist = ngb.pred_dist(X_test)
     # test properties of output
-    import pickle
-
-    ngb = pickle.loads(pickle.dumps(ngb))
-    ngb.pred_dist(X_test)
 
 
 @pytest.mark.slow
@@ -174,7 +170,3 @@ def test_multivariatenormal(k: 2, learner):
     y_dist.rv()
     y_dist.params
     scipy_list = y_dist.scipy_distribution()
-    import pickle
-
-    ngb = pickle.loads(pickle.dumps(ngb))
-    ngb.pred_dist(X_test)

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -164,9 +164,8 @@ def test_multivariatenormal(k: 2, learner):
     y_pred = ngb.predict(X_test)
     y_dist = ngb.pred_dist(X_test)
 
-    y_dist.loc
-    y_dist.mean
-    y_dist.cov
-    y_dist.rv()
-    y_dist.params
+    mean = y_dist.mean
+    cmat = y_dist.cov
+    sample = y_dist.rv()
+    params = y_dist.params
     scipy_list = y_dist.scipy_distribution()

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -16,6 +16,7 @@ from ngboost.distns import (
     TFixedDf,
     TFixedDfFixedVar,
     k_categorical,
+    MultivariateNormal,
 )
 from ngboost.scores import CRPScore, LogScore, Score
 
@@ -135,4 +136,38 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
     # test properties of output
 
 
-# test slicing and ._params
+@pytest.mark.slow
+@pytest.mark.parametrize("k", [2, 3])
+@pytest.mark.parametrize(
+    "learner",
+    [
+        DecisionTreeRegressor(criterion="friedman_mse", max_depth=5),
+        DecisionTreeRegressor(criterion="friedman_mse", max_depth=3),
+    ],
+)
+def test_multivariatenormal(k: 2, learner):
+    dist = MultivariateNormal(k)
+
+    # Generate some sample data
+    N = 500
+    X_train = np.random.randn(N, k)
+    y_fns = [np.sin, np.cos, np.exp]
+    y_cols = [
+        fn(X_train[:, num_col]).reshape(-1, 1) + np.random.randn(N, 1)
+        for num_col, fn in enumerate(y_fns[:k])
+    ]
+    y_train = np.hstack(y_cols)
+    X_test = np.random.randn(N, k)
+
+    ngb = NGBRegressor(Dist=dist, Score=LogScore, Base=learner, verbose=False)
+    ngb.fit(X_train, y_train)
+    y_pred = ngb.predict(X_test)
+    y_dist = ngb.pred_dist(X_test)
+
+    y_dist.loc
+    y_dist.mean
+    y_dist.cov
+    y_dist.rv()
+    y_dist.params
+    scipy_list = y_dist.scipy_distribution()
+

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -11,12 +11,12 @@ from ngboost.distns import (
     Distn,
     Exponential,
     LogNormal,
+    MultivariateNormal,
     Normal,
     T,
     TFixedDf,
     TFixedDfFixedVar,
     k_categorical,
-    MultivariateNormal,
 )
 from ngboost.scores import CRPScore, LogScore, Score
 
@@ -134,6 +134,10 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
     y_prob = ngb.predict_proba(X_test)
     y_dist = ngb.pred_dist(X_test)
     # test properties of output
+    import pickle
+
+    ngb = pickle.loads(pickle.dumps(ngb))
+    ngb.pred_dist(X_test)
 
 
 @pytest.mark.slow
@@ -170,4 +174,7 @@ def test_multivariatenormal(k: 2, learner):
     y_dist.rv()
     y_dist.params
     scipy_list = y_dist.scipy_distribution()
+    import pickle
 
+    ngb = pickle.loads(pickle.dumps(ngb))
+    ngb.pred_dist(X_test)

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,136 @@
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+from scipy.optimize import approx_fprime
+
+from ngboost.distns import (
+    Cauchy,
+    Distn,
+    Laplace,
+    MultivariateNormal,
+    Normal,
+    Poisson,
+    T,
+    TFixedDf,
+    TFixedDfFixedVar,
+)
+from ngboost.manifold import manifold
+from ngboost.scores import CRPScore, LogScore, Score
+
+DistScore = Tuple[Distn, Score]
+
+
+def sample_metric(manifold_obj, n_mc_samples=1000):
+    """
+    Copied from LogScore.
+    This can be removed if LogScore.metric is accessible
+    after inheritance
+
+    Args:
+        n_mc_samples: Number of samples to estimate metric with
+        manifold_obj (Manifold): A manifold with d_score and sample attributes
+
+    Returns:
+        An estimate of the fisher information
+
+    """
+    grads = np.stack(
+        [manifold_obj.d_score(np.array([Y])) for Y in manifold_obj.sample(n_mc_samples)]
+    )
+    return np.mean(np.einsum("sik,sij->sijk", grads, grads), axis=0)
+
+
+def estimate_grad_err(params: np.ndarray, manifold_test):
+    """
+    Args:
+        params: Initial parameters to test around
+        manifold_test (Manifold): The manifold to obtain errors for
+
+    Returns:
+        grad_err: An gradient error estimate using finite differences
+                    and manifold_test.d_score()
+
+    """
+    D = manifold_test(params)
+    # The y data to evaluate the score/gradient at
+    y = D.sample(1)
+
+    # The following returns the gradient for parameters x
+    grad = lambda x: manifold_test(x.reshape(-1, 1)).score(y)
+    grad_approx = approx_fprime(params.flatten(), grad, 1e-6)
+    grad_true = D.d_score(y)
+    err = np.linalg.norm(grad_approx - grad_true)
+    grad_err = err / D.n_params
+    return grad_err
+
+
+def estimate_metric_err(params: np.ndarray, manifold_test):
+    """
+    Args:
+        params: Initial parameters to test around
+        manifold_test (Manifold): The manifold to obtain errors for
+
+    Returns:
+        metric_err: An error estimate between a sampling estimate of metric
+                    and manifold_test.metric()
+    """
+    D = manifold_test(params)
+    metric_est = sample_metric(D, n_mc_samples=10000)
+    metric_true = D.metric()
+
+    # Normalize by the norm of the true metric
+    metric_err = np.linalg.norm((metric_est - metric_true)) / np.linalg.norm(
+        metric_true
+    )
+    return metric_err
+
+
+def idfn(dist_score: DistScore):
+    dist, score = dist_score
+    return dist.__name__ + "_" + score.__name__
+
+
+TEST_METRIC: List[DistScore] = [
+    (Normal, LogScore),
+    (Normal, CRPScore),
+    (TFixedDfFixedVar, LogScore),
+    (Laplace, LogScore),
+    (Poisson, LogScore),
+] + [(MultivariateNormal(i), LogScore) for i in range(2, 5)]
+# Fill in the dist, score pair to test the gradient
+# Tests all in TEST_METRIC by default
+TEST_GRAD: List[DistScore] = TEST_METRIC + [
+    (Cauchy, LogScore),
+    (T, LogScore),
+    (TFixedDf, LogScore),
+]
+
+
+@pytest.mark.parametrize("dist_score_pair", TEST_GRAD, ids=idfn)
+def test_dists_grad(dist_score_pair: DistScore):
+    # Set seed as this test involves randomness
+    # All errors around 1e-5 mark
+    np.random.seed(9)
+    dist, score = dist_score_pair
+    params = np.random.rand(dist.n_params, 1)
+    manifold_test = manifold(score, dist)
+    grad_err = estimate_grad_err(params, manifold_test)
+    assert grad_err < 1e-3
+    # TODO: Laplace CRPScore currently fails this test
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("dist_score_pair", TEST_METRIC, ids=idfn)
+@pytest.mark.parametrize("seed", [18])
+def test_dists_metric(dist_score_pair: DistScore, seed: int):
+    # Set seed as this test involves randomness
+    # Note if this test fails on a new distribution
+    # There is a chance it is due to randomness
+    np.random.seed(seed)
+    dist, score = dist_score_pair
+    params = np.random.rand(dist.n_params, 1)
+    manifold_test = manifold(LogScore, dist)
+    FI_err = estimate_metric_err(params, manifold_test)
+    assert FI_err < 1e-1
+    # TODO: TFixedDF, Cauchy currently fail this test


### PR DESCRIPTION
**Implementation of multivariate  normal distribution just for regression with LogScore.**

It does not use the scipy implementation primarily as I found scipy was much slower.

Got the idea from a paper I mentioned in the doc string of `distns.multivariate_normal`. I recreated one of the experiments from the paper in `experiments/multivariate_normal.py` and results seem very similar.

Here's a sanity check I did against a tensorflow implementation for a 3 dimensional multivariate normal, I can share my calculations for the Fisher Information soon if needed, they are currently very messy.
[mvn_comparison.pdf](https://github.com/stanfordmlgroup/ngboost/files/6015943/mvn_comparison.pdf)

*Deleted the old implementation*

I did override the old MultivariateNormal class. I salvaged a few bits (the .fit method) but the rest is all new. I could not see any score implementations so I assume this was legacy code.

**changes to `ngboost.py`** 
I had to add a self.multi_output attribute which defaults to False if the Dist does not have a multi_output attribute. 
Also, changed `__set_state__` and `__get_state__`  to allow pickling as the MultivariateNormal implementation is a function factory like k_categorical. 

**P.S.** This is my first pull request so I am fully expecting something to go wrong.


EDIT: Here's the derivations might have typos let me know if its' not clear
[MVN_DERIV.pdf](https://github.com/stanfordmlgroup/ngboost/files/6032054/MVN_DERIV.pdf)
