### PR TITLE
add codeowners file and bump version for latest merges

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* ryan-wolbeck alejandroschuler tonyduan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.3.8dev"
+version = "0.3.9dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"


### PR DESCRIPTION
This PR will close #233 
This will automatically add the people in the codeowners file to the reviewers list on PRs. I'm also updating the version before I publish a new version of the package to make recent changes live on pypi

Thanks,
Ryan