### PR TITLE
Add Sklearn-like Early Stopping for NGBoostRegressor

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -63,7 +63,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
         tol=1e-4,
         random_state=None,
         validation_fraction=0.1,
-        auto_early_stopping_rounds=10
+        auto_early_stopping_rounds=None
     ):
         assert issubclass(
             Dist, RegressionDistn

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -62,6 +62,8 @@ class NGBRegressor(NGBoost, BaseEstimator):
         verbose_eval=100,
         tol=1e-4,
         random_state=None,
+        validation_fraction=0.1,
+        auto_early_stopping_rounds=10
     ):
         assert issubclass(
             Dist, RegressionDistn
@@ -85,6 +87,8 @@ class NGBRegressor(NGBoost, BaseEstimator):
             verbose_eval,
             tol,
             random_state,
+            validation_fraction,
+            auto_early_stopping_rounds
         )
 
     def __getstate__(self):

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -44,6 +44,12 @@ class NGBRegressor(NGBoost, BaseEstimator):
         tol               : numerical tolerance to be used in optimization
         random_state      : seed for reproducibility. See
                             https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
+        validation_fraction: Proportion of training data to set aside as validation data for early stopping.
+        early_stopping_rounds:      The number of consecutive boosting iterations during which the
+                                    loss has to increase before the algorithm stops early.
+                                    Set to None to disable early stopping and validation.
+                                    None enables running over the full data set.
+
     Output:
         An NGBRegressor object that can be fit.
     """
@@ -63,7 +69,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
         tol=1e-4,
         random_state=None,
         validation_fraction=0.1,
-        auto_early_stopping_rounds=None
+        early_stopping_rounds=None
     ):
         assert issubclass(
             Dist, RegressionDistn
@@ -88,7 +94,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
             tol,
             random_state,
             validation_fraction,
-            auto_early_stopping_rounds
+            early_stopping_rounds
         )
 
     def __getstate__(self):
@@ -104,112 +110,6 @@ class NGBRegressor(NGBoost, BaseEstimator):
             state_dict["Dist"] = state_dict["Dist"].uncensor(state_dict["Score"])
         super().__setstate__(state_dict)
 
-
-class NGBESRegressor(NGBRegressor):
-    """
-    Constructor for NGBESRegressor regression models.
-    NGBESRegressor is a wrapper for the NGBRegressor class which adopts Sklearn HistGradientBoostingRegressor-like automatic early stopping.
-    Initial parameters are the same as NGBRegressor except for two extra params
-    validation_fraction and early_stopping_rounds (definitions below)
-
-    Parameters:
-        Dist              : assumed distributional form of Y|X=x.
-                            A distribution from ngboost.distns, e.g. Normal
-        Score             : rule to compare probabilistic predictions P̂ to the observed data y.
-                            A score from ngboost.scores, e.g. LogScore
-        Base              : base learner to use in the boosting algorithm.
-                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()
-        natural_gradient  : logical flag indicating whether the natural gradient should be used
-        n_estimators      : the number of boosting iterations to fit
-        learning_rate     : the learning rate
-        minibatch_frac    : the percent subsample of rows to use in each boosting iteration
-        col_sample        : the percent subsample of columns to use in each boosting iteration
-        verbose           : flag indicating whether output should be printed during fitting
-        verbose_eval      : increment (in boosting iterations) at which output should be printed
-        tol               : numerical tolerance to be used in optimization
-        random_state      : seed for reproducibility. See
-                            https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
-        validation_fraction: Proportion of training data to set aside as validation data for early stopping.
-        early_stopping_rounds: the number of consecutive boosting iterations during which
-                               the loss has to increase before the algorithm stops early.
-                               Set to None to disable early stopping and validation.  None enables running over the full data set.
-    Output:
-        An NGBESRegressor object that can be fit.
-    """
-
-    def __init__(
-        self,
-        Dist=Normal,
-        Score=LogScore,
-        Base=default_tree_learner,
-        natural_gradient=True,
-        n_estimators=500,
-        learning_rate=0.01,
-        minibatch_frac=1.0,
-        col_sample=1.0,
-        verbose=True,
-        verbose_eval=100,
-        tol=1e-4,
-        random_state=None,
-        validation_fraction=0.1,
-        early_stopping_rounds=10
-    ):
-        self.validation_fraction = validation_fraction
-        self.early_stopping_rounds = early_stopping_rounds
-        super().__init__(
-            Dist,
-            Score,
-            Base,
-            natural_gradient,
-            n_estimators,
-            learning_rate,
-            minibatch_frac,
-            col_sample,
-            verbose,
-            verbose_eval,
-            tol,
-            random_state,
-        )
-
-    def fit(self, X, Y, sample_weight=None):
-        """Fits an NGBoost survival model to the data.
-        For additional parameters see ngboost.NGboost.fit
-        Parameters:
-            X                     : DataFrame object or List or
-                                    numpy array of predictors (n x p) in Numeric format
-            Y                     : DataFrame object or List or numpy array of outcomes (n)
-                                    in numeric format. Should be floats for regression and
-                                    integers from 0 to K-1 for K-class classification
-            sample_weight         : how much to weigh each example in the training set.
-                                    numpy array of size (n) (defaults to 1)
-        """
-        # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
-        if self.early_stopping_rounds is not None:
-            if sample_weight is None:
-                X_train, X_val, y_train, y_val = train_test_split(X, Y,
-                    test_size=self.validation_fraction)
-                sample_weight_train = val_sample_weight = None
-            else:
-                (X_train, X_val, y_train, y_val, sample_weight_train,
-                val_sample_weight) = train_test_split(X, Y, sample_weight,
-                    test_size=self.validation_fraction)
-            #run fit with all of the validation parameters and with early stopping
-            return super().fit(
-                X_train,
-                y_train,
-                X_val=X_val,
-                Y_val=y_val,
-                sample_weight=sample_weight_train,
-                val_sample_weight=val_sample_weight,
-                early_stopping_rounds=self.early_stopping_rounds
-            )
-        #if no early stopping is specified, run for the whole data set.  No validation.
-        else:
-            return super().fit(
-                X,
-                Y,
-                sample_weight=sample_weight,
-            )
 
 class NGBClassifier(NGBoost, BaseEstimator):
     """

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -248,16 +248,16 @@ class NGBoost:
         self.validation_fraction
         self.auto_early_stopping_rounds
 
-        # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
-        if self.auto_early_stopping_rounds is not None:
-            if sample_weight is None:
-                X, X_val, Y, Y_val = train_test_split(X, Y,
-                    test_size=self.validation_fraction)
-                sample_weight = val_sample_weight = None
-            else:
-                (X, X_val, Y, Y_val, sample_weight,
-                val_sample_weight) = train_test_split(X, Y, sample_weight,
-                    test_size=self.validation_fraction)
+        ## if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
+        #if self.auto_early_stopping_rounds is not None:
+        #    if sample_weight is None:
+        #        X, X_val, Y, Y_val = train_test_split(X, Y,
+        #            test_size=self.validation_fraction)
+        #        sample_weight = val_sample_weight = None
+        #    else:
+        #        (X, X_val, Y, Y_val, sample_weight,
+        #        val_sample_weight) = train_test_split(X, Y, sample_weight,
+        #            test_size=self.validation_fraction)
 
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -247,7 +247,6 @@ class NGBoost:
         # This will overwrite any X_val and Y_val values passed by the user directly.
         
         if self.auto_early_stopping_rounds is not None:
-            print(self.random_state)
 
             early_stopping_rounds = self.auto_early_stopping_rounds
 
@@ -255,9 +254,11 @@ class NGBoost:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,
                                                       test_size=self.validation_fraction,
-                                                      random_state =41)
-                #sample_weight = None
-                #val_sample_weight = None
+                                                      random_state = self.random_state)
+                sample_weight = None
+                val_sample_weight = None
+
+                print(X[0], X[100], X_val[0], X_val[100])
             else:
                 X, X_val, Y, Y_val, sample_weight, val_sample_weight = train_test_split(X,
                                                                                         Y,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -255,7 +255,7 @@ class NGBoost:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,
                                                       test_size=self.validation_fraction,
-                                                      random_state =self.random_state)
+                                                      random_state =41)
                 #sample_weight = None
                 #val_sample_weight = None
             else:

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -256,14 +256,14 @@ class NGBoost:
                                                       Y,
                                                       test_size=self.validation_fraction,
                                                       random_state =self.random_state)
-                sample_weight = None
-                val_sample_weight = None
+                #sample_weight = None
+                #val_sample_weight = None
             else:
-                (X, X_val, Y, Y_val, sample_weight, val_sample_weight) = train_test_split(X,
-                                                                                          Y,
-                                                                                          sample_weight,
-                                                                                          test_size=self.validation_fraction,
-                                                                                          random_state = self.random_state)
+                X, X_val, Y, Y_val, sample_weight, val_sample_weight = train_test_split(X,
+                                                                                        Y,
+                                                                                        sample_weight,
+                                                                                        test_size=self.validation_fraction,
+                                                                                        random_state = self.random_state)
 
         params = self.pred_param(X)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -248,16 +248,20 @@ class NGBoost:
         self.validation_fraction
         self.auto_early_stopping_rounds
 
-        ## if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
-        #if self.auto_early_stopping_rounds is not None:
-        #    if sample_weight is None:
-        #        X, X_val, Y, Y_val = train_test_split(X, Y,
-        #            test_size=self.validation_fraction)
-        #        sample_weight = val_sample_weight = None
-        #    else:
-        #        (X, X_val, Y, Y_val, sample_weight,
-        #        val_sample_weight) = train_test_split(X, Y, sample_weight,
-        #            test_size=self.validation_fraction)
+        # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
+        if self.auto_early_stopping_rounds is not None:
+            if sample_weight is None:
+                X, X_val, Y, Y_val = train_test_split(X,
+                                                      Y,
+                                                      test_size=self.validation_fraction)
+                print(len(X), len(Y))
+                sample_weight = None
+                val_sample_weight = None
+            else:
+                (X, X_val, Y, Y_val, sample_weight, val_sample_weight) = train_test_split(X,
+                                                                                          Y,
+                                                                                          sample_weight,
+                                                                                          test_size=self.validation_fraction)
 
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -258,7 +258,7 @@ class NGBoost:
                 sample_weight = None
                 val_sample_weight = None
 
-                print(X[0], X[100], X_val[0], X_val[100])
+                print(X[0], X[20], X_val[0], X_val[20])
             else:
                 X, X_val, Y, Y_val, sample_weight, val_sample_weight = train_test_split(X,
                                                                                         Y,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -243,8 +243,6 @@ class NGBoost:
         loss_list = []
         self.fit_init_params_to_marginal(Y)
 
-        params = self.pred_param(X)
-
         self.validation_fraction
         self.auto_early_stopping_rounds
 
@@ -262,6 +260,8 @@ class NGBoost:
                                                                                           Y,
                                                                                           sample_weight,
                                                                                           test_size=self.validation_fraction)
+
+        params = self.pred_param(X)
 
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(
@@ -282,7 +282,6 @@ class NGBoost:
             )  # NOQA
 
         for itr in range(self.n_estimators):
-            print(len(X), len(Y))
             _, col_idx, X_batch, Y_batch, weight_batch, P_batch = self.sample(
                 X, Y, sample_weight, params
             )

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -233,16 +233,6 @@ class NGBoost:
             A fit NGBRegressor object
         """
 
-        if Y is None:
-            raise ValueError("y cannot be None")
-
-        X, Y = check_X_y(X, Y, y_numeric=True, multi_output=self.multi_output)
-
-        self.n_features = X.shape[1]
-
-        loss_list = []
-        self.fit_init_params_to_marginal(Y)
-
         # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
         # This will overwrite any X_val and Y_val values passed by the user directly.
         
@@ -254,7 +244,7 @@ class NGBoost:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,
                                                       test_size=self.validation_fraction,
-                                                      random_state = 41)
+                                                      random_state = self.random_state)
                 sample_weight = None
                 val_sample_weight = None
 
@@ -264,7 +254,18 @@ class NGBoost:
                                                                                         Y,
                                                                                         sample_weight,
                                                                                         test_size=self.validation_fraction,
-                                                                                        random_state = 41)
+                                                                                        random_state = self.random_state)
+
+
+        if Y is None:
+            raise ValueError("y cannot be None")
+
+        X, Y = check_X_y(X, Y, y_numeric=True, multi_output=self.multi_output)
+
+        self.n_features = X.shape[1]
+
+        loss_list = []
+        self.fit_init_params_to_marginal(Y)
 
         params = self.pred_param(X)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -248,6 +248,9 @@ class NGBoost:
 
         # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
         if self.auto_early_stopping_rounds is not None:
+
+            early_stopping_rounds = self.auto_early_stopping_rounds
+
             if sample_weight is None:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -258,7 +258,7 @@ class NGBoost:
                 sample_weight = None
                 val_sample_weight = None
 
-                print(X[0], X[20], X_val[0], X_val[20])
+                print(X[0][0], X[20][0], X_val[0][0], X_val[20][0], Y[20], Y_val[20])
             else:
                 X, X_val, Y, Y_val, sample_weight, val_sample_weight = train_test_split(X,
                                                                                         Y,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -245,10 +245,7 @@ class NGBoost:
                                                       Y,
                                                       test_size=self.validation_fraction,
                                                       random_state = self.random_state)
-                sample_weight = None
-                val_sample_weight = None
 
-                print(X[0][0], X[20][0], X_val[0][0], X_val[20][0], Y[20], Y_val[20])
             else:
                 X, X_val, Y, Y_val, sample_weight, val_sample_weight = train_test_split(X,
                                                                                         Y,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -39,6 +39,13 @@ class NGBoost:
         tol               : numerical tolerance to be used in optimization
         random_state      : seed for reproducibility.
                             See https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
+        validation_fraction: Proportion of training data to set aside as validation data for early stopping.
+        auto_early_stopping_rounds: The number of consecutive boosting iterations during which the
+                                    loss has to increase before the algorithm stops early.
+                                    Set to None to disable early stopping and validation.
+                                    None enables running over the full data set.
+
+
     Output:
         An NGBRegressor object that can be fit.
     """
@@ -58,7 +65,7 @@ class NGBoost:
         tol=1e-4,
         random_state=None,
         validation_fraction=0.1,
-        auto_early_stopping_rounds = None # Distinct from early_stopping_rounds, but doesn't need to be.
+        early_stopping_rounds = None # Distinct from early_stopping_rounds, but doesn't need to be.
     ):
         self.Dist = Dist
         self.Score = Score
@@ -80,7 +87,7 @@ class NGBoost:
         self.random_state = check_random_state(random_state)
         self.best_val_loss_itr = None
         self.validation_fraction = validation_fraction
-        self.auto_early_stopping_rounds = auto_early_stopping_rounds
+        self.early_stopping_rounds = early_stopping_rounds
 
         if hasattr(self.Dist, "multi_output"):
             self.multi_output = self.Dist.multi_output
@@ -236,9 +243,9 @@ class NGBoost:
         # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
         # This will overwrite any X_val and Y_val values passed by the user directly.
         
-        if self.auto_early_stopping_rounds is not None:
+        if self.early_stopping_rounds is not None:
 
-            early_stopping_rounds = self.auto_early_stopping_rounds
+            early_stopping_rounds = self.early_stopping_rounds
 
             if sample_weight is None:
                 X, X_val, Y, Y_val = train_test_split(X,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -58,7 +58,7 @@ class NGBoost:
         tol=1e-4,
         random_state=None,
         validation_fraction=0.1,
-        auto_early_stopping_rounds = 10 # Distinct from early_stopping_rounds
+        auto_early_stopping_rounds = None # Distinct from early_stopping_rounds, but doesn't need to be.
     ):
         self.Dist = Dist
         self.Score = Score
@@ -243,10 +243,9 @@ class NGBoost:
         loss_list = []
         self.fit_init_params_to_marginal(Y)
 
-        self.validation_fraction
-        self.auto_early_stopping_rounds
-
         # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
+        # This will overwrite any X_val and Y_val values passed by the user directly.
+        
         if self.auto_early_stopping_rounds is not None:
 
             early_stopping_rounds = self.auto_early_stopping_rounds

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -254,7 +254,7 @@ class NGBoost:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,
                                                       test_size=self.validation_fraction,
-                                                      random_state = self.random_state)
+                                                      random_state = 41)
                 sample_weight = None
                 val_sample_weight = None
 
@@ -264,7 +264,7 @@ class NGBoost:
                                                                                         Y,
                                                                                         sample_weight,
                                                                                         test_size=self.validation_fraction,
-                                                                                        random_state = self.random_state)
+                                                                                        random_state = 41)
 
         params = self.pred_param(X)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -282,7 +282,7 @@ class NGBoost:
             )  # NOQA
 
         for itr in range(self.n_estimators):
-            print(len(X), len(Y), len(sample_weight))
+            print(len(X), len(Y))
             _, col_idx, X_batch, Y_batch, weight_batch, P_batch = self.sample(
                 X, Y, sample_weight, params
             )

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -254,15 +254,16 @@ class NGBoost:
             if sample_weight is None:
                 X, X_val, Y, Y_val = train_test_split(X,
                                                       Y,
-                                                      test_size=self.validation_fraction)
-                print(len(X), len(Y))
+                                                      test_size=self.validation_fraction,
+                                                      random_state =self.random_state)
                 sample_weight = None
                 val_sample_weight = None
             else:
                 (X, X_val, Y, Y_val, sample_weight, val_sample_weight) = train_test_split(X,
                                                                                           Y,
                                                                                           sample_weight,
-                                                                                          test_size=self.validation_fraction)
+                                                                                          test_size=self.validation_fraction,
+                                                                                          random_state = self.random_state)
 
         params = self.pred_param(X)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -7,6 +7,7 @@ import numpy as np
 from sklearn.base import clone
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.utils import check_array, check_random_state, check_X_y
+from sklearn.model_selection import train_test_split
 
 from ngboost.distns import MultivariateNormal, Normal, k_categorical
 from ngboost.learners import default_tree_learner
@@ -56,6 +57,8 @@ class NGBoost:
         verbose_eval=100,
         tol=1e-4,
         random_state=None,
+        validation_fraction=0.1,
+        auto_early_stopping_rounds = 10 # Distinct from early_stopping_rounds
     ):
         self.Dist = Dist
         self.Score = Score
@@ -76,6 +79,9 @@ class NGBoost:
         self.tol = tol
         self.random_state = check_random_state(random_state)
         self.best_val_loss_itr = None
+        self.validation_fraction = validation_fraction
+        self.auto_early_stopping_rounds = auto_early_stopping_rounds
+
         if hasattr(self.Dist, "multi_output"):
             self.multi_output = self.Dist.multi_output
         else:
@@ -238,6 +244,21 @@ class NGBoost:
         self.fit_init_params_to_marginal(Y)
 
         params = self.pred_param(X)
+
+        self.validation_fraction
+        self.auto_early_stopping_rounds
+
+        # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
+        if self.auto_early_stopping_rounds is not None:
+            if sample_weight is None:
+                X, X_val, Y, Y_val = train_test_split(X, Y,
+                    test_size=self.validation_fraction)
+                sample_weight = val_sample_weight = None
+            else:
+                (X, X_val, Y, Y_val, sample_weight,
+                val_sample_weight) = train_test_split(X, Y, sample_weight,
+                    test_size=self.validation_fraction)
+
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(
                 X_val, Y_val, y_numeric=True, multi_output=self.multi_output

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -247,6 +247,7 @@ class NGBoost:
         # This will overwrite any X_val and Y_val values passed by the user directly.
         
         if self.auto_early_stopping_rounds is not None:
+            print(self.random_state)
 
             early_stopping_rounds = self.auto_early_stopping_rounds
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -282,6 +282,7 @@ class NGBoost:
             )  # NOQA
 
         for itr in range(self.n_estimators):
+            print(len(X), len(Y), len(sample_weight))
             _, col_idx, X_batch, Y_batch, weight_batch, P_batch = self.sample(
                 X, Y, sample_weight, params
             )

--- a/ngboost/ngboost_early_stop_test_single_api.ipynb
+++ b/ngboost/ngboost_early_stop_test_single_api.ipynb
@@ -1,0 +1,457 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "dcWql3jpKIu9"
+      },
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "ModuleNotFoundError",
+          "evalue": "No module named 'ngboost.distns'; 'ngboost' is not a package",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "\u001b[1;32m<ipython-input-2-a9d7d5cf981a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[1;32mc:\\Users\\kmedv\\OneDrive\\github\\public_dev\\ngboost\\ngboost\\ngboost.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m     10\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0msklearn\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodel_selection\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mtrain_test_split\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     11\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 12\u001b[1;33m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdistns\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMultivariateNormal\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNormal\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mk_categorical\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     13\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mlearners\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mdefault_tree_learner\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     14\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmanifold\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mmanifold\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'ngboost.distns'; 'ngboost' is not a package"
+          ]
+        }
+      ],
+      "source": [
+        "import ngboost"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mnT8rC2zJ7gL"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.datasets import load_boston\n",
+        "from ngboost import NGBRegressor\n",
+        "from sklearn.tree import DecisionTreeRegressor\n",
+        "from sklearn.datasets import load_boston\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import mean_squared_error\n",
+        "\n",
+        "\n",
+        "#https://stanfordmlgroup.github.io/ngboost/1-useage.html\n",
+        "\n",
+        "X, y = load_boston(True)\n",
+        "X_train, X_test, Y_train, Y_test = train_test_split(X, y, test_size=0.1, random_state = 42)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9nNY9BaTnWsL",
+        "outputId": "d003e1e3-8de1-4643-abe5-7d0df94c2fc4"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "51"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "len(X_test)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "UdAzDT2JnFHS"
+      },
+      "outputs": [],
+      "source": [
+        "base_learner = DecisionTreeRegressor(random_state = 55)\n",
+        "ngb = NGBRegressor()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 305
+        },
+        "id": "5D2-1G2fnLjq",
+        "outputId": "4f8b7233-b67f-40dd-8854-7e1c5b1f53b0"
+      },
+      "outputs": [
+        {
+          "ename": "ValueError",
+          "evalue": "ignored",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-6-413cf94ee1c6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mngb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX_train\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mY_train\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/ngboost/ngboost.py\u001b[0m in \u001b[0;36mfit\u001b[0;34m(self, X, Y, X_val, Y_val, sample_weight, val_sample_weight, train_loss_monitor, val_loss_monitor, early_stopping_rounds)\u001b[0m\n\u001b[1;32m    297\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlearning_rate\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    298\u001b[0m                 \u001b[0;34m*\u001b[0m \u001b[0mscale\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 299\u001b[0;31m                 \u001b[0;34m*\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol_idx\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mm\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbase_models\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mT\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    300\u001b[0m             )\n\u001b[1;32m    301\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mValueError\u001b[0m: operands could not be broadcast together with shapes (455,2) (409,2) (455,2) "
+          ]
+        }
+      ],
+      "source": [
+        "ngb.fit(X_train, Y_train)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 322
+        },
+        "id": "XE2VzXJYM6H4",
+        "outputId": "29548a63-1c40-4c73-a577-fed8caecb2e7"
+      },
+      "outputs": [
+        {
+          "ename": "ValueError",
+          "evalue": "ignored",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-4-29b80a39ea64>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mbase_learner\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mDecisionTreeRegressor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrandom_state\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m55\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mngb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNGBRegressor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrandom_state\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m55\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mBase\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbase_learner\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX_train\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mY_train\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mX_val\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mX_test\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mY_val\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mY_test\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mearly_stopping_rounds\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[0;32m/usr/local/lib/python3.7/dist-packages/ngboost/ngboost.py\u001b[0m in \u001b[0;36mfit\u001b[0;34m(self, X, Y, X_val, Y_val, sample_weight, val_sample_weight, train_loss_monitor, val_loss_monitor, early_stopping_rounds)\u001b[0m\n\u001b[1;32m    297\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlearning_rate\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    298\u001b[0m                 \u001b[0;34m*\u001b[0m \u001b[0mscale\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 299\u001b[0;31m                 \u001b[0;34m*\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol_idx\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mm\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbase_models\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mT\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    300\u001b[0m             )\n\u001b[1;32m    301\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mValueError\u001b[0m: operands could not be broadcast together with shapes (455,2) (409,2) (455,2) "
+          ]
+        }
+      ],
+      "source": [
+        "base_learner = DecisionTreeRegressor(random_state = 55)\n",
+        "ngb = NGBRegressor(random_state = 55, Base = base_learner).fit(X_train, Y_train, X_val = X_test, Y_val = Y_test, early_stopping_rounds = 10)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vix1ggDQPpkE",
+        "outputId": "07e5112e-8d8a-426b-c1f7-756d21f2aa27"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[iter 0] loss=3.6441 val_loss=0.0000 scale=2.0000 norm=13.5053\n",
+            "[iter 100] loss=2.3805 val_loss=0.0000 scale=2.0000 norm=2.1737\n",
+            "[iter 200] loss=1.1195 val_loss=0.0000 scale=4.0000 norm=2.0294\n",
+            "[iter 300] loss=-0.9605 val_loss=0.0000 scale=8.0000 norm=3.9999\n",
+            "[iter 400] loss=-4.5948 val_loss=0.0000 scale=4.0000 norm=1.9884\n"
+          ]
+        }
+      ],
+      "source": [
+        "base_learner = DecisionTreeRegressor(random_state = 42)\n",
+        "ngbh = NGBHistGradientBoostingRegressor(random_state = 42, Base = base_learner, early_stopping_rounds = None, validation_fraction = None).fit(X_train, Y_train)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VdgRpPXGEqkI",
+        "outputId": "aa660123-a246-42b3-b38c-8608eaaece3b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "14.61412374848873"
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "Y_preds = ngbh.predict(X_test)\n",
+        "\n",
+        "test_MSE = mean_squared_error(Y_preds, Y_test)\n",
+        "test_MSE"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "aH5V1Pm-EUxX",
+        "outputId": "903e2789-2b97-4534-cc40-e97a7cd0746c"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[iter 0] loss=3.6441 val_loss=0.0000 scale=2.0000 norm=13.5053\n",
+            "[iter 100] loss=2.3805 val_loss=0.0000 scale=2.0000 norm=2.1737\n",
+            "[iter 200] loss=1.1195 val_loss=0.0000 scale=4.0000 norm=2.0294\n",
+            "[iter 300] loss=-0.9605 val_loss=0.0000 scale=8.0000 norm=3.9999\n",
+            "[iter 400] loss=-4.5948 val_loss=0.0000 scale=4.0000 norm=1.9884\n"
+          ]
+        }
+      ],
+      "source": [
+        "base_learner = DecisionTreeRegressor(random_state = 42)\n",
+        "\n",
+        "ngb = NGBRegressor(random_state = 42, Base = base_learner).fit(X_train, Y_train)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LxQT5cj-EwIA",
+        "outputId": "4a0e3728-71a0-4768-e5c6-18b98228dc16"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "14.61412374848873"
+            ]
+          },
+          "execution_count": 17,
+          "metadata": {
+            "tags": []
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "Y_preds = ngb.predict(X_test)\n",
+        "\n",
+        "test_MSE = mean_squared_error(Y_preds, Y_test)\n",
+        "test_MSE"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "EiY9jNyNRhVs"
+      },
+      "outputs": [],
+      "source": [
+        "class NGBRegressor2(NGBoost, BaseEstimator):\n",
+        "    \"\"\"\n",
+        "    Constructor for NGBoost regression models.\n",
+        "    NGBRegressor is a wrapper for the generic NGBoost class that facilitates regression.\n",
+        "    Use this class if you want to predict an outcome that could take an\n",
+        "    infinite number of (ordered) values.\n",
+        "    Parameters:\n",
+        "        Dist              : assumed distributional form of Y|X=x.\n",
+        "                            A distribution from ngboost.distns, e.g. Normal\n",
+        "        Score             : rule to compare probabilistic predictions P̂ to the observed data y.\n",
+        "                            A score from ngboost.scores, e.g. LogScore\n",
+        "        Base              : base learner to use in the boosting algorithm.\n",
+        "                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()\n",
+        "        natural_gradient  : logical flag indicating whether the natural gradient should be used\n",
+        "        n_estimators      : the number of boosting iterations to fit\n",
+        "        learning_rate     : the learning rate\n",
+        "        minibatch_frac    : the percent subsample of rows to use in each boosting iteration\n",
+        "        col_sample        : the percent subsample of columns to use in each boosting iteration\n",
+        "        verbose           : flag indicating whether output should be printed during fitting\n",
+        "        verbose_eval      : increment (in boosting iterations) at which output should be printed\n",
+        "        tol               : numerical tolerance to be used in optimization\n",
+        "        random_state      : seed for reproducibility. See\n",
+        "                            https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn\n",
+        "    Output:\n",
+        "        An NGBRegressor object that can be fit.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    def __init__(\n",
+        "        self,\n",
+        "        Dist=Normal,\n",
+        "        Score=LogScore,\n",
+        "        Base=default_tree_learner,\n",
+        "        natural_gradient=True,\n",
+        "        n_estimators=500,\n",
+        "        learning_rate=0.01,\n",
+        "        minibatch_frac=1.0,\n",
+        "        col_sample=1.0,\n",
+        "        verbose=True,\n",
+        "        verbose_eval=100,\n",
+        "        tol=1e-4,\n",
+        "        random_state=None,\n",
+        "        validation_fraction=0.1,\n",
+        "        early_stopping_rounds=10\n",
+        "    ):\n",
+        "        self.validation_fraction = validation_fraction\n",
+        "        self.early_stopping_rounds = early_stopping_rounds\n",
+        "\n",
+        "        assert issubclass(\n",
+        "            Dist, RegressionDistn\n",
+        "        ), f\"{Dist.__name__} is not useable for regression.\"\n",
+        "\n",
+        "        if not hasattr(\n",
+        "            Dist, \"scores\"\n",
+        "        ):  # user is trying to use a dist that only has censored scores implemented\n",
+        "            Dist = Dist.uncensor(Score)\n",
+        "\n",
+        "        super().__init__(\n",
+        "            Dist,\n",
+        "            Score,\n",
+        "            Base,\n",
+        "            natural_gradient,\n",
+        "            n_estimators,\n",
+        "            learning_rate,\n",
+        "            minibatch_frac,\n",
+        "            col_sample,\n",
+        "            verbose,\n",
+        "            verbose_eval,\n",
+        "            tol,\n",
+        "            random_state,\n",
+        "        )\n",
+        "\n",
+        "    def __getstate__(self):\n",
+        "        state = super().__getstate__()\n",
+        "        # Remove the unpicklable entries.\n",
+        "        if self.Dist.__name__ == \"DistWithUncensoredScore\":\n",
+        "            state[\"Dist\"] = self.Dist.__base__\n",
+        "            state[\"uncensor\"] = True\n",
+        "        return state\n",
+        "\n",
+        "    def __setstate__(self, state_dict):\n",
+        "        if \"uncensor\" in state_dict.keys():\n",
+        "            state_dict[\"Dist\"] = state_dict[\"Dist\"].uncensor(state_dict[\"Score\"])\n",
+        "        super().__setstate__(state_dict)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kq2SOQAzRlRE",
+        "outputId": "d15a7710-fef6-428f-af35-e7053160131e"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[iter 0] loss=3.6497 val_loss=3.4925 scale=2.0000 norm=13.6949\n",
+            "[iter 100] loss=2.3897 val_loss=2.6101 scale=2.0000 norm=2.1963\n",
+            "== Early stopping achieved.\n",
+            "== Best iteration / VAL128 (val_loss=2.5474)\n"
+          ]
+        }
+      ],
+      "source": [
+        "ngb = NGBRegressor2(random_state = 55, Base = base_learner).fit(X_train, Y_train, X_val = X_test, Y_val = Y_test, early_stopping_rounds = 10)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-6Dei3UJRoS3"
+      },
+      "outputs": [],
+      "source": [
+        "ngb = NGBRegressor2(random_state = 55, Base = base_learner)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hUSg1rGaRpaA"
+      },
+      "outputs": [],
+      "source": [
+        "    def __init__(\n",
+        "        self,\n",
+        "        Dist=Normal,\n",
+        "        Score=LogScore,\n",
+        "        Base=default_tree_learner,\n",
+        "        natural_gradient=True,\n",
+        "        n_estimators=500,\n",
+        "        learning_rate=0.01,\n",
+        "        minibatch_frac=1.0,\n",
+        "        col_sample=1.0,\n",
+        "        verbose=True,\n",
+        "        verbose_eval=100,\n",
+        "        tol=1e-4,\n",
+        "        random_state=None,\n",
+        "        validation_fraction=0.1,\n",
+        "        early_stopping_rounds=10\n",
+        "    ):\n",
+        "        self.validation_fraction = validation_fraction\n",
+        "        self.early_stopping_rounds = early_stopping_rounds\n",
+        "        super().__init__(\n",
+        "            Dist,\n",
+        "            Score,\n",
+        "            Base,\n",
+        "            natural_gradient,\n",
+        "            n_estimators,\n",
+        "            learning_rate,\n",
+        "            minibatch_frac,\n",
+        "            col_sample,\n",
+        "            verbose,\n",
+        "            verbose_eval,\n",
+        "            tol,\n",
+        "            random_state,\n",
+        "        )"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "ngboost_early_stop_test_single_api.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python388jvsc74a57bd05d77bcbfe0ddfc9aac099013962771256b50750ac7c5540853f470393e4277e6",
+      "display_name": "Python 3.8.8 64-bit ('darko': conda)"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.8.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/ngboost_early_stop_test_single_api.ipynb
+++ b/ngboost_early_stop_test_single_api.ipynb
@@ -2,35 +2,56 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {
         "id": "dcWql3jpKIu9"
       },
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "ModuleNotFoundError",
-          "evalue": "No module named 'ngboost.distns'; 'ngboost' is not a package",
-          "traceback": [
-            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-            "\u001b[1;32m<ipython-input-2-a9d7d5cf981a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[1;32mc:\\Users\\kmedv\\OneDrive\\github\\public_dev\\ngboost\\ngboost\\ngboost.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m     10\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0msklearn\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodel_selection\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mtrain_test_split\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     11\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 12\u001b[1;33m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdistns\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMultivariateNormal\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNormal\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mk_categorical\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     13\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mlearners\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mdefault_tree_learner\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     14\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mngboost\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmanifold\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mmanifold\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-            "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'ngboost.distns'; 'ngboost' is not a package"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import ngboost"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "mnT8rC2zJ7gL"
-      },
+      "execution_count": 2,
+      "metadata": {},
       "outputs": [],
+      "source": [
+        "from ngboost import NGBRegressor\n",
+        "from sklearn.base import BaseEstimator\n",
+        "from sklearn.utils import check_array\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.model_selection import ShuffleSplit\n",
+        "from sklearn.model_selection import GroupShuffleSplit\n",
+        "\n",
+        "from ngboost.distns import (\n",
+        "    Bernoulli,\n",
+        "    ClassificationDistn,\n",
+        "    LogNormal,\n",
+        "    Normal,\n",
+        "    RegressionDistn,\n",
+        ")\n",
+        "from ngboost.distns.utils import SurvivalDistnClass\n",
+        "from ngboost.helpers import Y_from_censored\n",
+        "from ngboost.learners import default_tree_learner\n",
+        "from ngboost.manifold import manifold\n",
+        "from ngboost.ngboost import NGBoost\n",
+        "from ngboost.scores import LogScore"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "C:\\Users\\kmedv\\anaconda3\\envs\\darko\\lib\\site-packages\\sklearn\\utils\\validation.py:67: FutureWarning: Pass return_X_y=True as keyword args. From version 0.25 passing these as positional arguments will result in an error\n  warnings.warn(\"Pass {} as keyword args. From version 0.25 \"\n"
+          ]
+        }
+      ],
       "source": [
         "from sklearn.datasets import load_boston\n",
         "from ngboost import NGBRegressor\n",
@@ -43,7 +64,42 @@
         "#https://stanfordmlgroup.github.io/ngboost/1-useage.html\n",
         "\n",
         "X, y = load_boston(True)\n",
-        "X_train, X_test, Y_train, Y_test = train_test_split(X, y, test_size=0.1, random_state = 42)"
+        "X_train, X_test, Y_train, Y_test = train_test_split(X, y, test_size=0.1, random_state = 41)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "mnT8rC2zJ7gL"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[iter 0] loss=3.6579 val_loss=3.4377 scale=2.0000 norm=13.6804\n",
+            "== Early stopping achieved.\n",
+            "== Best iteration / VAL59 (val_loss=3.0712)\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "NGBRegressor(Base=DecisionTreeRegressor(random_state=41),\n",
+              "             auto_early_stopping_rounds=10,\n",
+              "             random_state=RandomState(MT19937) at 0x1FE523E2C40)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
+      ],
+      "source": [
+        "base_learner = DecisionTreeRegressor(random_state = 41)\n",
+        "ngb = NGBRegressor(Base = base_learner, validation_fraction=0.1, random_state = 41, auto_early_stopping_rounds=10)\n",
+        "ngb.fit(X, y)"
       ]
     },
     {


### PR DESCRIPTION
This is a pull request following up on the discussion here: https://github.com/stanfordmlgroup/ngboost/discussions/234, creating a new class called NGBESRegressor (NGB Early Stopping Regressor), which follows the [HistGradientBoostingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html) approach of automatically doing early stopping, rather than requiring the user to specify their own validation data.

This fits a bit better within the rest of the scikit-learn ecosystem, which mostly does not allow the user to pass validation data into `.fit()` calls, and thus creates problems for Hyperparameter tuning for instance. 

This is a new class rather than a change to NGBRegressor directly in response to @tonyduan 's suggestion that the user still be able to pass their own validation data if they prefer. Creating a unified API which allowed for both proved difficult, so a separate class was needed. I did not do one for NGBClassifier or the NGBSurvival classes yet, although if there's interest this can be replicated across them.

Thank you to @darrendefreeuw for actually doing the underlying coding here.