### PR TITLE
Allow sparse X, fixes #271

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -297,10 +297,10 @@ class NGBSurvival(NGBoost, BaseEstimator):
                                     validation-set event idicators, in numeric format if any
         """
 
-        X = check_array(X)
+        X = check_array(X, accept_sparse=True)
 
         if X_val is not None:
-            X_val = check_array(X_val)
+            X_val = check_array(X_val, accept_sparse=True)
 
         return super().fit(
             X,

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -344,7 +344,7 @@ class NGBoost:
             A NGBoost distribution object
         """
 
-        X = check_array(X)
+        X = check_array(X, accept_sparse=True)
 
         if (
             max_iter is not None
@@ -395,7 +395,7 @@ class NGBoost:
             Numpy array of the estimates of Y
         """
 
-        X = check_array(X)
+        X = check_array(X, accept_sparse=True)
 
         return self.pred_dist(X, max_iter=max_iter).predict()
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -230,7 +230,7 @@ class NGBoost:
         if Y is None:
             raise ValueError("y cannot be None")
 
-        X, Y = check_X_y(X, Y, y_numeric=True, multi_output=self.multi_output)
+        X, Y = check_X_y(X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output)
 
         self.n_features = X.shape[1]
 
@@ -240,7 +240,7 @@ class NGBoost:
         params = self.pred_param(X)
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(
-                X_val, Y_val, y_numeric=True, multi_output=self.multi_output
+                X_val, Y_val, accept_sparse=True, y_numeric=True, multi_output=self.multi_output
             )
             val_params = self.pred_param(X_val)
             val_loss_list = []

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -230,7 +230,9 @@ class NGBoost:
         if Y is None:
             raise ValueError("y cannot be None")
 
-        X, Y = check_X_y(X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output)
+        X, Y = check_X_y(
+            X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output
+        )
 
         self.n_features = X.shape[1]
 
@@ -240,7 +242,11 @@ class NGBoost:
         params = self.pred_param(X)
         if X_val is not None and Y_val is not None:
             X_val, Y_val = check_X_y(
-                X_val, Y_val, accept_sparse=True, y_numeric=True, multi_output=self.multi_output
+                X_val,
+                Y_val,
+                accept_sparse=True,
+                y_numeric=True,
+                multi_output=self.multi_output,
             )
             val_params = self.pred_param(X_val)
             val_loss_list = []


### PR DESCRIPTION
Allow sparse `X` when fitting and predicting - fixes #271.

An example using the new version:

```python
from ngboost import NGBSurvival
import numpy as np
import scipy.sparse as sp
from time import perf_counter

def generate_X_T_E(n, d):
    X = np.random.choice(2, p=[0.9, 0.1], size=(n, d))
    T = np.random.rand(n)
    E = np.random.randint(2, size=n)
    return X, T, E

n_train = 10000
n_val = 1000
d = 3000

X, T, E = generate_X_T_E(n_train, d)
X_val, T_val, E_val = generate_X_T_E(n_val, d)

# Full/dense
ngb = NGBSurvival(n_estimators=101, learning_rate=0.1, verbose_eval=10, random_state=0)
t0 = perf_counter()
ngb.fit(X, T, E, X_val=X_val, T_val=T_val, E_val=E_val, early_stopping_rounds=50)
print(perf_counter() - t0, "s")

t0 = perf_counter()
y_dists = ngb.pred_dist(X_val)
print(perf_counter() - t0, "s")
print(y_dists.params["s"].mean())

# Sparse
ngb = NGBSurvival(n_estimators=101, learning_rate=0.1, verbose_eval=10, random_state=0)
t0 = perf_counter()
ngb.fit(sp.csr_matrix(X), T, E, X_val=sp.csr_matrix(X_val), T_val=T_val, E_val=E_val, early_stopping_rounds=50)
print(perf_counter() - t0, "s")

t0 = perf_counter()
y_dists = ngb.pred_dist(sp.csr_matrix(X_val))
print(perf_counter() - t0, "s")
print(y_dists.params["s"].mean())
```

which gives me a 5x speed increase (as in, it takes 20% of the time to run) when using sparse `X`, and gives the same predicted output to 15 decimal places.