### PR TITLE
Add set_params for sklearn compatibility.

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -371,6 +371,35 @@ class NGBoost:
 
         return self
 
+    def set_params(self, **parameters):
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self
+
+    def get_params(self, deep=True):
+        """
+        Parameters
+        ----------
+        deep : Ignored. (for compatibility with sklearn)
+        Returns
+        ----------
+        params : returns an dictionary of parameters.
+        """
+        params = {'Dist' : self.Dist,
+                  'Score' : self.Score,
+                  'Base' : self.Base,
+                  'natural_gradient' : self.natural_gradient,
+                   'n_estimators' : self.n_estimators,
+                   'learning_rate' : self.learning_rate,
+                   'minibatch_frac' : self.minibatch_frac,
+                   'col_sample' : self.col_sample,
+                   'verbose' : self.verbose,
+                   'random_state' : self.random_state,
+                   }
+
+        return params
+    
+    
     def score(self, X, Y):  # for sklearn
         return self.Manifold(self.pred_dist(X)._params).total_score(Y)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -398,8 +398,7 @@ class NGBoost:
                    }
 
         return params
-    
-    
+   
     def score(self, X, Y):  # for sklearn
         return self.Manifold(self.pred_dist(X)._params).total_score(Y)
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -385,20 +385,21 @@ class NGBoost:
         ----------
         params : returns an dictionary of parameters.
         """
-        params = {'Dist' : self.Dist,
-                  'Score' : self.Score,
-                  'Base' : self.Base,
-                  'natural_gradient' : self.natural_gradient,
-                   'n_estimators' : self.n_estimators,
-                   'learning_rate' : self.learning_rate,
-                   'minibatch_frac' : self.minibatch_frac,
-                   'col_sample' : self.col_sample,
-                   'verbose' : self.verbose,
-                   'random_state' : self.random_state,
-                   }
+        params = {
+            "Dist": self.Dist,
+            "Score": self.Score,
+            "Base": self.Base,
+            "natural_gradient": self.natural_gradient,
+            "n_estimators": self.n_estimators,
+            "learning_rate": self.learning_rate,
+            "minibatch_frac": self.minibatch_frac,
+            "col_sample": self.col_sample,
+            "verbose": self.verbose,
+            "random_state": self.random_state,
+        }
 
         return params
-   
+
     def score(self, X, Y):  # for sklearn
         return self.Manifold(self.pred_dist(X)._params).total_score(Y)
 


### PR DESCRIPTION
Add set_params, get_params for sklearn compatibility.
This change makes it easier to use with optimization libraries such as optuna or GridSearchCV.
https://scikit-learn.org/stable/modules/generated/sklearn.base.BaseEstimator.html

Here is the pseudo code.
```
model = NGBoost(Base=default_tree_learner, Dist=Normal, natural_gradient=True, verbose=False)
def objective(trial):
    return something

study = optuna.create_study()
study.optimize(objective, n_trials=10)
model.set_params(study.best_params)
```
