### PR TITLE
Bump python version due to lack of support for 3.6.0 from Pandas. Fix…

### DIFF
--- a/ngboost/evaluation.py
+++ b/ngboost/evaluation.py
@@ -43,7 +43,7 @@ def plot_pit_histogram(predicted, observed, **kwargs):
         align="edge",
         fill=False,
         edgecolor="black",
-        **kwargs
+        **kwargs,
     )
     plt.xlim((0, 1))
     plt.xlabel("Probability Integral Transform")
@@ -62,7 +62,7 @@ def plot_calibration_curve(predicted, observed):
         np.linspace(0, 1),
         np.linspace(0, 1) * slope + intercept,
         "--",
-        label="Slope: %.2f, Intercept: %.2f" % (slope, intercept),
+        label=f"Slope: {slope:.2f}, Intercept: {intercept:.2f}",
         alpha=0.5,
         color="black",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.6.1, <4.0"
+python = ">=3.6.2, <4.0"
 scikit-learn = ">=0.21"
 numpy = ">=1.17"
 scipy = ">=1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.6, <4.0"
+python = ">=3.6.1, <4.0"
 scikit-learn = ">=0.21"
 numpy = ">=1.17"
 scipy = ">=1.3"


### PR DESCRIPTION
… pylint issue.

See [#285](https://github.com/stanfordmlgroup/ngboost/issues/285).

As a further note, `pylint`, a dev dependency of this project now only supports python versions 3.6.2 and greater. It might be worth bumping the min version to 3.6.2 rather than just 3.6.1.