### PR TITLE
add sklearn dictionary support get_param and version update

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -371,6 +371,35 @@ class NGBoost:
 
         return self
 
+    def set_params(self, **parameters):
+        for parameter, value in parameters.items():
+             setattr(self, parameter, value)
+        return self
+
+    def get_params(self, deep=True):
+        """
+        Parameters
+        ----------
+        deep : Ignored. (for compatibility with sklearn)
+        Returns
+        ----------
+        params : returns an dictionary of parameters.
+        """
+        params = {
+            "Dist": self.Dist,
+            "Score": self.Score,
+            "Base": self.Base,
+            "natural_gradient": self.natural_gradient,
+            "n_estimators": self.n_estimators,
+            "learning_rate": self.learning_rate,
+            "minibatch_frac": self.minibatch_frac,
+            "col_sample": self.col_sample,
+            "verbose": self.verbose,
+            "random_state": self.random_state,
+    }
+
+        return params
+
     def score(self, X, Y):  # for sklearn
         return self.Manifold(self.pred_dist(X)._params).total_score(Y)
 


### PR DESCRIPTION
This pull request adds sklearn dictionary compatibility and the gamma distribution to ngboost 0.4.0. 

Sklearn dictionary compatibility allows users to use the ngboost library with the same syntax and functionality as other sklearn compatible libraries. The gamma distribution can be used to fit regression and classification models. 

This pull request includes the following changes:
- Added sklearn dictionary compatibility (re-created from #284)
- Bump version to 0.40 (to release package with updates here and the gamma dist)

