### PR TITLE
Shift flake8 to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ scipy = ">=1.7.2"
 tqdm = ">=4.3"
 lifelines = ">=0.25"
 pandas = ">=1.3.5"
-flake8 = "^5.0.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"
@@ -28,6 +27,7 @@ black = "^22.8.0"
 pre-commit = "^2.0"
 isort = "^5.6.4"
 pylint = "^2.6.0"
+flake8 = "^5.0.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
flake8 does not need to be installed with the shipped package. This will reduce the number of installed packages from `pip install ngboost`