### PR TITLE
Remove declared pandas dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ numpy = ">=1.21.2"
 scipy = ">=1.7.2"
 tqdm = ">=4.3"
 lifelines = ">=0.25"
-pandas = ">=1.3.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"


### PR DESCRIPTION
Pandas is not required at run-time nor during development. It is required to run the example notebooks, but these seem to have separately tracked requirements [here](https://github.com/stanfordmlgroup/ngboost/blob/master/examples/user-guide/requirements.txt) and [here](https://github.com/stanfordmlgroup/ngboost/blob/master/docs/requirements.txt).

Note that lifelines (used in `ngboost.evaluation`) does require pandas, so ngboost still requires it transitively. Lifelines has a less stringent pandas requirement than what's currently provided.