### PR TITLE
Add py311, remove py37

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/experiments/survival_exp.py
+++ b/examples/experiments/survival_exp.py
@@ -24,7 +24,9 @@ base_name_to_learner = {
 def Y_join(T, E):
     col_event = "Event"
     col_time = "Time"
-    y = np.empty(dtype=[(col_event, np.bool), (col_time, np.float64)], shape=T.shape[0])
+    y = np.empty(
+        dtype=[(col_event, np.bool_), (col_time, np.float64)], shape=T.shape[0]
+    )
     y[col_event] = E.values
     y[col_time] = T.values
     return y

--- a/ngboost/helpers.py
+++ b/ngboost/helpers.py
@@ -17,7 +17,7 @@ def Y_from_censored(T, E=None):
     else:
         E = check_array(E, ensure_2d=False)
         E = E.reshape(E.shape[0])
-    Y = np.empty(dtype=[("Event", np.bool), ("Time", np.float64)], shape=T.shape[0])
-    Y["Event"] = E.astype(np.bool)
+    Y = np.empty(dtype=[("Event", np.bool_), ("Time", np.float64)], shape=T.shape[0])
+    Y["Event"] = E.astype(np.bool_)
     Y["Time"] = T.astype(np.float64)
     return Y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,12 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7.1, <3.11"
+python = ">=3.8, <3.12"
 scikit-learn = ">=1.0.2"
 numpy = ">=1.21.2"
 scipy = ">=1.7.2"
 tqdm = ">=4.3"
 lifelines = ">=0.25"
-pandas = ">=1.3.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"


### PR DESCRIPTION
Fixes #319

It is easiest to implement [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html). All current versions of numpy, scipy, scikit-learn are built for 3.8-3.11 (and do not support Python 3.7)

Pandas can be removed as it is a transitive dependency only.

`np.bool` was deprecated in NumPy 1.20.