### PR TITLE
feat: Add estimator type with reg and clf for NGBClassifier and NGBRegressor

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -96,6 +96,8 @@ class NGBRegressor(NGBoost, BaseEstimator):
             validation_fraction,
             early_stopping_rounds,
         )
+        
+        self._estimator_type = "regressor"
 
     def __getstate__(self):
         state = super().__getstate__()
@@ -172,6 +174,7 @@ class NGBClassifier(NGBoost, BaseEstimator):
             tol,
             random_state,
         )
+        self._estimator_type = "classifier"
 
     def predict_proba(self, X, max_iter=None):
         """


### PR DESCRIPTION
- Problem: Currently, when using NGBClassifier or NGBRegressor with the sklearn ensemble voting classifier or regressor, a ValueError is returned with the message "The estimator NGBClassifier / NGBRegressor should be a classifier / regressor."

- Solution: Added two attributes, self._estimator_type = "classifier" and self._estimator_type = "regressor", into the NGBClassifier and NGBRegressor classes respectively. These attributes indicate whether the model is a classifier or a regressor, allowing the models to be correctly identified by the sklearn ensemble voting classifier or regressor.

- Impact: This change should resolve the ValueError issue when using NGBClassifier or NGBRegressor with the sklearn ensemble voting classifier or regressor, improving the usability of the models in an ensemble learning setting.
