### PR TITLE
Enable Base models that don't accept sample weight

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -162,9 +162,14 @@ class NGBoost:
         )
 
     def fit_base(self, X, grads, sample_weight=None):
-        models = [
-            clone(self.Base).fit(X, g, sample_weight=sample_weight) for g in grads.T
-        ]
+        if sample_weight is None:
+            models = [
+                clone(self.Base).fit(X, g) for g in grads.T
+            ]
+        else:
+            models = [
+                clone(self.Base).fit(X, g, sample_weight=sample_weight) for g in grads.T
+            ]
         fitted = np.array([m.predict(X) for m in models]).T
         self.base_models.append(models)
         return fitted
@@ -286,9 +291,9 @@ class NGBoost:
             Y_val                 : DataFrame object or List or
                                     numpy array of validation-set outcomes in numeric format
             sample_weight         : how much to weigh each example in the training set.
-                                    numpy array of size (n) (defaults to 1)
+                                    numpy array of size (n) (defaults to None)
             val_sample_weight     : how much to weigh each example in the validation set.
-                                    (defaults to 1)
+                                    (defaults to None)
             train_loss_monitor    : a custom score or set of scores to track on the training set
                                     during training. Defaults to the score defined in the NGBoost
                                     constructor


### PR DESCRIPTION
This change enables using Base models that don't accept the keyword argument `sample_weight` (for example, `sklearn.neural_network.MLPRegressor`) when the user specifies or defaults to `sample_weight=None`. In this case, `fit()` is called without this keyword argument.

The alternatives would be to use the library `inspect` to check whether the base model's `fit()` accepts this keyword argument and split cases from there, or handle the exception thrown when the unexpected keyword argument is received, but this is pretty simple in comparison.