### PR TITLE
Bugfix/np bool deprecation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         files: ^ngboost
         entry: flake8
       - id: pylint-ngboost
-        name: pylint on nboost*
+        name: pylint on ngboost*
         types: [file, python]
         language: system
         files: ^ngboost

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## Version 0.4.2
+* Fix deprecated numpy type alias. This was causing a warning with NumPy >=1.20 and an error with NumPy >=1.24.
+* Remove pandas as a declared dependency
+
 ## Version 0.4.1
 ### Added `partial_fit` method for incremental learning
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # RELEASE NOTES
 
 ## Version 0.4.2
-* Fix deprecated numpy type alias. This was causing a warning with NumPy >=1.20 and an error with NumPy >=1.24.
+* Fix deprecated numpy type alias. This was causing a warning with NumPy >=1.20 and an error with NumPy >=1.24
 * Remove pandas as a declared dependency
 
 ## Version 0.4.1

--- a/examples/experiments/survival_exp.py
+++ b/examples/experiments/survival_exp.py
@@ -24,7 +24,9 @@ base_name_to_learner = {
 def Y_join(T, E):
     col_event = "Event"
     col_time = "Time"
-    y = np.empty(dtype=[(col_event, np.bool), (col_time, np.float64)], shape=T.shape[0])
+    y = np.empty(
+        dtype=[(col_event, np.bool_), (col_time, np.float64)], shape=T.shape[0]
+    )
     y[col_event] = E.values
     y[col_time] = T.values
     return y

--- a/ngboost/helpers.py
+++ b/ngboost/helpers.py
@@ -17,7 +17,7 @@ def Y_from_censored(T, E=None):
     else:
         E = check_array(E, ensure_2d=False)
         E = E.reshape(E.shape[0])
-    Y = np.empty(dtype=[("Event", np.bool), ("Time", np.float64)], shape=T.shape[0])
-    Y["Event"] = E.astype(np.bool)
+    Y = np.empty(dtype=[("Event", np.bool_), ("Time", np.float64)], shape=T.shape[0])
+    Y["Event"] = E.astype(np.bool_)
     Y["Time"] = T.astype(np.float64)
     return Y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.4.1dev"
+version = "0.4.2dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -26,8 +26,8 @@ from ngboost.scores import CRPScore, LogScore, Score
 # check metric lines up with defaults for lognormal where applicable
 
 
-Tuple4Array = Tuple[np.array, np.array, np.array, np.array]
-Tuple5Array = Tuple[np.array, np.array, np.array, np.array, np.array]
+Tuple4Array = Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+Tuple5Array = Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 
 
 @pytest.mark.slow
@@ -151,7 +151,7 @@ def test_categorical(k: int, learner, breast_cancer_data: Tuple4Array):
 )
 # Ignore the k=1 warning
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_multivariatenormal(k: 2, learner):
+def test_multivariatenormal(k: int, learner):
     dist = MultivariateNormal(k)
 
     # Generate some sample data


### PR DESCRIPTION
`np.bool` was deprecated in NumPy 1.20.0. Reference:
* https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
* https://numpy.org/doc/stable/user/basics.types.html#array-types-and-conversions-between-types

This call became an error in NumPy 1.24.0, see https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations