### PR TITLE
Fix issue causing large memory consumption in pred_dist()

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -315,7 +315,6 @@ class NGBoost:
         # if early stopping is specified, split X,Y and sample weights (if given) into training and validation sets
         # This will overwrite any X_val and Y_val values passed by the user directly.
         if self.early_stopping_rounds is not None:
-
             early_stopping_rounds = self.early_stopping_rounds
 
             if sample_weight is None:
@@ -490,13 +489,9 @@ class NGBoost:
 
         X = check_array(X, accept_sparse=True)
 
-        if (
-            max_iter is not None
-        ):  # get prediction at a particular iteration if asked for
-            dist = self.staged_pred_dist(X, max_iter=max_iter)[-1]
-        else:
-            params = np.asarray(self.pred_param(X, max_iter))
-            dist = self.Dist(params.T)
+        params = np.asarray(self.pred_param(X, max_iter))
+        dist = self.Dist(params.T)
+
         return dist
 
     def staged_pred_dist(self, X, max_iter=None):


### PR DESCRIPTION
Hi,

I was recently working on a project and when inspecting resource usage realized memory consumption was way too high for `.pred_dist()` when passing a `max_iter` value other than `None`.

When inspecting the code, I realized that the issue stemmed from using `.staged_pred_dist()` but only returning the last value. This resulted in unnecessary memory allocation (in my case hundreds of GBs).

```
if (
    max_iter is not None
):  # get prediction at a particular iteration if asked for
    dist = self.staged_pred_dist(X, max_iter=max_iter)[-1]   <-- Only using last Dist obj, but allocates memory for max_iter * Dist objects
```

Also, the conditional statement wasn't really needed. All it was checking for is if `max_iter` is `None` or not, but `pred_param()` can already handle that case.

This PR fixes the aforementioned issues.

Thanks!
