### PR TITLE
Add support for python 3.12, drop python 3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12"
+python = ">=3.8, <3.13"
 scikit-learn = ">=1.0.2"
 numpy = ">=1.21.2"
 scipy = ">=1.7.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ pytest = "^6.1.2"
 black = "^22.8.0"
 pre-commit = "^2.0"
 isort = "^5.6.4"
-pylint = "^2.6.0"
-flake8 = "^5.0.4"
+pylint = "^3.0.3"
+flake8 = "^7.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.13"
+python = ">=3.9, <3.13"
 scikit-learn = ">=1.0.2"
 numpy = ">=1.21.2"
 scipy = ">=1.7.2"


### PR DESCRIPTION
## Summary

Closes #345 

- Adds support for python 3.12, and adds to the CI matrix
- Removes support for python 3.8, removes from the CI matrix
- Updates the pinned versions of flake8 and pylint

## Discussion

It was seemingly necessary to drop support for python 3.8 to enable poetry to allow numpy `1.26`. If 3.8 support is retained, poetry only allows numpy up to `1.24` which has a bug on python 3.12: https://github.com/numpy/numpy/issues/23808

According to [SPEC 0](https://scientific-python.org/specs/spec-0000/) (which superseded [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html)), python 3.8 is overdue to be dropped:

> On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)