### PR TITLE
Release 0.5.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## Version 0.5.0
 
 * Drops support for python 3.7 and 3.8
-* Now support for Python 3.11 and 3.12
+* Now supports Python 3.11 and 3.12
 * Fixed issue with np.bool
 * Optimized memory usage in pred-dist
 * Removed declared pandas dependency

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,22 @@
 # RELEASE NOTES
 
+## Version 0.5.0
+
+* Drops support for python 3.7 and 3.8
+* Now support for Python 3.11 and 3.12
+* Fixed issue with np.bool
+* Optimized memory usage in pred-dist
+* Removed declared pandas dependency
+* Significant improvements to run times on tests during development
+* Minor enhancements to github actions
+
 ## Version 0.4.2
+
 * Fix deprecated numpy type alias. This was causing a warning with NumPy >=1.20 and an error with NumPy >=1.24
 * Remove pandas as a declared dependency
 
 ## Version 0.4.1
+
 ### Added `partial_fit` method for incremental learning
 
 NGBoost now includes a new `partial_fit` method that allows for incremental learning. This method appends new base models to the existing ones, which can be useful when new data becomes available over time or when the data is too large to fit in memory all at once.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.4.2dev"
+version = "0.5.0dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"


### PR DESCRIPTION
Given significant changes to Python support this release bumps the minor version up.

## Version 0.5.0

* Drops support for python 3.7 and 3.8
* Now supports Python 3.11 and 3.12
* Fixed issue with np.bool
* Optimized memory usage in pred-dist
* Removed declared pandas dependency
* Significant improvements to run times on tests during development
* Minor enhancements to github actions