### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ package:
 	poetry build
 
 publish: package
-	poetry publish
+    source .env && poetry config pypi-token.pypi $$PYPI_TOKEN && poetry publish
 
 lint:
 	poetry run pre-commit run --hook-stage manual --all-files
@@ -15,4 +15,4 @@ test:
 	poetry run pytest --slow -v
 
 clean:
-	rm -r build dist ngboost.egg-info
+	rm -rf dist/*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ package:
 	poetry build
 
 publish: package
-    source .env && poetry config pypi-token.pypi $$PYPI_TOKEN && poetry publish
+	source .env && poetry config pypi-token.pypi $$PYPI_TOKEN && poetry publish
 
 lint:
 	poetry run pre-commit run --hook-stage manual --all-files

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## Version 0.5.1
+
+* Adds support for NormalFixedMean distribution
+* Updates to makefile for easier publishing
+
 ## Version 0.5.0
 
 * Drops support for python 3.7 and 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.0dev"
+version = "0.5.1dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"


### PR DESCRIPTION
This PR is intended to make the PYPI publishing easier by setting the api token in a .env file. Also updates clean to just remove old dist files after publishing a release so later versions are not re-uploaded.

example .env
`PYPI_TOKEN=your_token`