### PR TITLE
Allow NaNs in input X

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -493,7 +493,7 @@ class NGBoost:
             A NGBoost distribution object
         """
 
-        X = check_array(X, accept_sparse=True)
+        X = check_array(X, accept_sparse=True, force_all_finite="allow-nan")
 
         params = np.asarray(self.pred_param(X, max_iter))
         dist = self.Dist(params.T)
@@ -540,7 +540,7 @@ class NGBoost:
             Numpy array of the estimates of Y
         """
 
-        X = check_array(X, accept_sparse=True)
+        X = check_array(X, accept_sparse=True, force_all_finite="allow-nan")
 
         return self.pred_dist(X, max_iter=max_iter).predict()
 

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -1,4 +1,5 @@
 """The NGBoost library"""
+
 # pylint: disable=line-too-long,too-many-instance-attributes,too-many-arguments
 # pylint: disable=unused-argument,too-many-locals,too-many-branches,too-many-statements
 # pylint: disable=unused-variable,invalid-unary-operand-type,attribute-defined-outside-init
@@ -338,7 +339,12 @@ class NGBoost:
             raise ValueError("y cannot be None")
 
         X, Y = check_X_y(
-            X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output
+            X,
+            Y,
+            accept_sparse=True,
+            force_all_finite="allow-nan",
+            multi_output=self.multi_output,
+            y_numeric=True,
         )
 
         self.n_features = X.shape[1]
@@ -353,8 +359,9 @@ class NGBoost:
                 X_val,
                 Y_val,
                 accept_sparse=True,
-                y_numeric=True,
+                force_all_finite="allow-nan",
                 multi_output=self.multi_output,
+                y_numeric=True,
             )
             val_params = self.pred_param(X_val)
             val_loss_list = []


### PR DESCRIPTION
This change allows NaNs in X (in train, validation, and test) matching what is permitted by XGBoost.