### PR TITLE
Fix Numpy Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "Apache License 2.0"
 [tool.poetry.dependencies]
 python = ">=3.9, <3.13"
 scikit-learn = ">=1.0.2"
-numpy = ">=1.21.2"
+numpy = ">=1.21.2, <2.0.0"
 scipy = ">=1.7.2"
 tqdm = ">=4.3"
 lifelines = ">=0.25"


### PR DESCRIPTION
Numpy 2.0.0 and greater is not compatible with NGBoost currently.

This PR adds a numpy dependency to prevent 2.0.0 or later from being used.

See #358 