### PR TITLE
Add support for Numpy 2.*, fix linting issues

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -54,6 +54,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
         An NGBRegressor object that can be fit.
     """
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         Dist=Normal,
@@ -142,6 +143,7 @@ class NGBClassifier(NGBoost, BaseEstimator):
         An NGBClassifier object that can be fit.
     """
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         Dist=Bernoulli,
@@ -235,6 +237,7 @@ class NGBSurvival(NGBoost, BaseEstimator):
         An NGBSurvival object that can be fit.
     """
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         Dist=LogNormal,
@@ -293,6 +296,7 @@ class NGBSurvival(NGBoost, BaseEstimator):
         state_dict["Manifold"] = manifold(state_dict["Score"], state_dict["Dist"])
         self.__dict__ = state_dict
 
+    # pylint: disable=too-many-positional-arguments
     def fit(self, X, T, E, X_val=None, T_val=None, E_val=None, **kwargs):
         """Fits an NGBoost survival model to the data.
         For additional parameters see ngboost.NGboost.fit

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -50,6 +50,7 @@ class NGBoost:
         An NGBRegressor object that can be fit.
     """
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         Dist=Normal,
@@ -172,6 +173,7 @@ class NGBoost:
         self.base_models.append(models)
         return fitted
 
+    # pylint: disable=too-many-positional-arguments
     def line_search(self, resids, start, Y, sample_weight=None, scale_init=1):
         D_init = self.Manifold(start.T)
         loss_init = D_init.total_score(Y, sample_weight)
@@ -201,6 +203,7 @@ class NGBoost:
         self.scalings.append(scale)
         return scale
 
+    # pylint: disable=too-many-positional-arguments
     def fit(
         self,
         X,
@@ -259,6 +262,7 @@ class NGBoost:
             early_stopping_rounds=early_stopping_rounds,
         )
 
+    # pylint: disable=too-many-positional-arguments
     def partial_fit(
         self,
         X,

--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -9,7 +9,7 @@ class Score:
         grad = self.d_score(Y)
         if natural:
             metric = self.metric()
-            grad = np.linalg.solve(metric, grad)
+            grad = np.linalg.solve(metric, grad[..., None])[..., 0]
         return grad
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.1dev"
+version = "0.5.2dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"


### PR DESCRIPTION
Currently, ngboost doesn't support Numpy 2.* due to a breaking change that was made for `numpy.linalg.solve`: see [#25914](https://github.com/numpy/numpy/pull/25914).

To give a brief explanation, `numpy.linalg.solve(a,b)` accepts two forms of input, either `a` as an `...xMxM` and `b` as an `...xMxK` matrix, where `numpy.linalg.solve` will treat `ax = b`, with `x` the `...MxK` matrix that solves this equation. The other form accepts `a` as an `...xMxM` and `b` as an `...xM` matrix, with `x` the `...xM`matrix that solves this equation. The `...` represent dimensions that view the problem as a set of solutions for stacked matrices/vectors, termed [broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html). Previous versions of numpy inferred that the calculation should be of the second type when the dimensions of `b` were one less than the dimensions of `a`. This resulted in some ambiguity in the case when `a` had 3 dimensions and `b` had 2 dimensions. As part of the changes made to Numpy in version 2.*, this ambiguity was removed and the second version was only assumed in the case that `b` had exactly one dimension, [see here](https://github.com/numpy/numpy/blob/c17d30da0e2d39a9bb0c8ef1efc8faafff24e98c/numpy/linalg/_linalg.py#L365).

There are two options to work around this, either using the what is suggested in [#25914](https://github.com/numpy/numpy/pull/25914) or manually using `_umath_linalg.solve1` instead of `numpy.linalg.solve`. I've opted for what was suggested as it is fairly simple.

I've also added some `pylint` disables to allow `make` to succeed. We could revisit these warnings to see if the functions can be refactored but the violations are pretty minor.