### PR TITLE
Updating poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 install:
-	pip install poetry==1.2.1 && poetry install
+	pip install poetry==2.0.1 && poetry install
 
 package:
 	poetry build


### PR DESCRIPTION
Updating `poetry` to version 2.0.1 as the current pinned version in `Makefile` is 1.2.1 and quite old at this point. Version 2.0.1 is compatible with Python 3.9 which is the minimum required for `ngboost` at the moment. A lot of improvements to `poetry` have been made from 1.2.1 to 2.0.1 and can be found [here](https://github.com/python-poetry/poetry/releases).