### PR TITLE
fix: syntax warning in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from sklearn.metrics import mean_squared_error
 
 #Load Boston housing dataset
 data_url = "http://lib.stat.cmu.edu/datasets/boston"
-raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
+raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
 X = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
 Y = raw_df.values[1::2, 2]
 

--- a/examples/regression.py
+++ b/examples/regression.py
@@ -9,7 +9,7 @@ from ngboost.distns import Normal
 if __name__ == "__main__":
     # Load Boston housing dataset
     data_url = "http://lib.stat.cmu.edu/datasets/boston"
-    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
+    raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
     X = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
     Y = raw_df.values[1::2, 2]
 

--- a/examples/survival.py
+++ b/examples/survival.py
@@ -9,7 +9,7 @@ from ngboost.distns import LogNormal
 if __name__ == "__main__":
     # Load Boston housing dataset
     data_url = "http://lib.stat.cmu.edu/datasets/boston"
-    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
+    raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
     X = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
     Y = raw_df.values[1::2, 2]
 


### PR DESCRIPTION
This fixes the `SyntaxWarning: invalid escape sequence '\s'` warning in the examples.