### PR TITLE
Update parameters in `get_params`

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -512,6 +512,8 @@ class NGBoost:
             "col_sample": self.col_sample,
             "verbose": self.verbose,
             "random_state": self.random_state,
+            "validation_fraction": self.validation_fraction,
+            "early_stopping_rounds": self.early_stopping_rounds,
         }
 
         return params


### PR DESCRIPTION
The two parameters `validation_fraction` and `early_stopping_rounds` have been added to the `params` dictionary.

See issue on cloning the model: #382 