### PR TITLE
fix: make col_sample min equals to 1

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -35,6 +35,7 @@ class NGBoost:
         n_estimators      : the number of boosting iterations to fit
         learning_rate     : the learning rate
         minibatch_frac    : the percent subsample of rows to use in each boosting iteration
+        col_sample        : the percent subsample of columns to use in each boosting iteration
         verbose           : flag indicating whether output should be printed during fitting
         verbose_eval      : increment (in boosting iterations) at which output should be printed
         tol               : numerical tolerance to be used in optimization
@@ -147,7 +148,10 @@ class NGBoost:
             )
 
         if self.col_sample != 1.0:
-            col_size = int(self.col_sample * X.shape[1])
+            if self.col_sample > 0.0:
+                col_size = max(1, int(self.col_sample * X.shape[1]))
+            else:
+                col_size = 0
             col_idx = self.random_state.choice(
                 np.arange(X.shape[1]), col_size, replace=False
             )


### PR DESCRIPTION
**Improved Column Sampling for Small Datasets**

In our current implementation, `col_sample` is treated as a percentage. When the number of columns is small and `col_sample` is also small, calculating the sampled columns with:

```
col_size = int(self.col_sample * X.shape[1])
```
can result in `col_size` being 0.

For example:
if there are 4 columns and `col_sample = 0.1`, then `int(0.1 * 4)` yields 0, which subsequently causes an error during model generation due to having 0 input features.

This pull request updates the logic to ensure that at least one column is always selected when `col_sample` is positive by using:

```
col_size = max(1, int(self.col_sample * X.shape[1])) if self.col_sample > 0 else 0
```

This change prevents errors in cases with a small number of features, improving the robustness of the model creation process.
