### PR TITLE
Enabling `python=3.13`

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.13"
+python = ">=3.9, <3.14"
 scikit-learn = "^1.6"
 numpy = ">=1.21.2"
 scipy = ">=1.7.2"


### PR DESCRIPTION
Adding `python=3.13` to make `ngboost` available for `shap` in Python 3.13 environments. See issue at `shap`'s repository: https://github.com/shap/shap/issues/3663