### PR TITLE
Update dev dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-default_stages: [commit, manual]
+default_stages: [pre-commit, manual]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -16,7 +16,7 @@ repos:
       - id: check-merge-conflict # Check for files that contain merge conflict strings.
       - id: debug-statements # Check for debugger imports and py37+ `breakpoint()` calls in python source.
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [pre-commit, manual]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # RELEASE NOTES
 
-## Version 0.5.5
+## Version 0.5.7
+
+* Support for Python 3.13
+* Update to dev dependencies
+
+## Version 0.5.6
 
 * Add support for Weibull and HalfNormal Distributions
 

--- a/examples/simulations/regression_sim.py
+++ b/examples/simulations/regression_sim.py
@@ -31,9 +31,7 @@ if __name__ == "__main__":
 
     X_train, X_test = (
         X[:1000, :],
-        X[
-            1000:,
-        ],
+        X[1000:,],
     )
     Y_train, Y_test = Y[:1000], Y[1000:]
 

--- a/examples/user-guide/scripts/clean.py
+++ b/examples/user-guide/scripts/clean.py
@@ -1,4 +1,5 @@
 """A helper script to "clean up" all of your generated markdown and HTML files."""
+
 import shutil as sh
 from pathlib import Path
 

--- a/figures/vis_crps.py
+++ b/figures/vis_crps.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     grads_y = np.zeros((20, 20))
     crps = np.zeros((20, 20))
 
-    for (i, j) in tqdm(itertools.product(np.arange(20), np.arange(20)), total=400):
+    for i, j in tqdm(itertools.product(np.arange(20), np.arange(20)), total=400):
         H = np.linalg.inv(metric_fn([loc[i, j], scale[i, j]]))
         g = np.array(grad_fn([loc[i, j], scale[i, j]]))
         gf = (H @ g).squeeze()

--- a/figures/vis_mle.py
+++ b/figures/vis_mle.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     grads_y = np.zeros((20, 20))
     nlls = np.zeros((20, 20))
 
-    for (i, j) in tqdm(itertools.product(np.arange(20), np.arange(20)), total=400):
+    for i, j in tqdm(itertools.product(np.arange(20), np.arange(20)), total=400):
         H = np.linalg.inv(fisher_fn([loc[i, j], scale[i, j]]))
         g = np.array(grad_fn([loc[i, j], scale[i, j]]))
         gf = (H @ g).squeeze()

--- a/ngboost/distns/__init__.py
+++ b/ngboost/distns/__init__.py
@@ -1,4 +1,5 @@
 """NGBoost distributions"""
+
 from .categorical import Bernoulli, k_categorical
 from .cauchy import Cauchy
 from .distn import ClassificationDistn, Distn, RegressionDistn

--- a/ngboost/distns/categorical.py
+++ b/ngboost/distns/categorical.py
@@ -1,4 +1,5 @@
 """The NGBoost categorial distribution and scores"""
+
 # pylint: disable=invalid-unary-operand-type, unused-argument
 import numpy as np
 import scipy as sp

--- a/ngboost/distns/cauchy.py
+++ b/ngboost/distns/cauchy.py
@@ -1,4 +1,5 @@
 """The NGBoost Cauchy distribution and scores"""
+
 from ngboost.distns.t import (
     TFixedDf,
     TFixedDfFixedVar,

--- a/ngboost/distns/distn.py
+++ b/ngboost/distns/distn.py
@@ -1,4 +1,5 @@
 """The NGBoost base distribution"""
+
 from warnings import warn
 
 import numpy as np

--- a/ngboost/distns/exponential.py
+++ b/ngboost/distns/exponential.py
@@ -1,4 +1,5 @@
 """The NGBoost Exponential distribution and scores"""
+
 import numpy as np
 import scipy as sp
 from scipy.stats import expon as dist

--- a/ngboost/distns/gamma.py
+++ b/ngboost/distns/gamma.py
@@ -1,4 +1,5 @@
 """The NGBoost Gamma distribution and scores"""
+
 import numpy as np
 import scipy as sp
 from scipy.stats import gamma as dist

--- a/ngboost/distns/halfnormal.py
+++ b/ngboost/distns/halfnormal.py
@@ -1,4 +1,5 @@
 """The NGBoost Half-Normal distribution and scores"""
+
 import numpy as np
 from scipy.stats import halfnorm as dist
 

--- a/ngboost/distns/laplace.py
+++ b/ngboost/distns/laplace.py
@@ -1,4 +1,5 @@
 """The NGBoost Laplace distribution and scores"""
+
 import numpy as np
 from scipy.stats import laplace as dist
 

--- a/ngboost/distns/lognormal.py
+++ b/ngboost/distns/lognormal.py
@@ -1,4 +1,5 @@
 """The NGBoost LogNormal distribution and scores"""
+
 import numpy as np
 import scipy as sp
 from scipy.stats import lognorm as dist
@@ -89,7 +90,6 @@ class LogNormalCRPScoreCensored(CRPScore):
 
 
 class LogNormal(RegressionDistn):
-
     """
     Implements the log-normal distribution for NGBoost.
 

--- a/ngboost/distns/multivariate_normal.py
+++ b/ngboost/distns/multivariate_normal.py
@@ -66,7 +66,6 @@ class MVNLogScore(LogScore):
         return gradient
 
     def metric(self):
-
         """
         Formulas for this part are not in the the paper mentioned.
         Obtained by taking the expectation of the Hessian.

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -1,4 +1,5 @@
 """The NGBoost Normal distribution and scores"""
+
 import numpy as np
 import scipy as sp
 from scipy.stats import norm as dist

--- a/ngboost/distns/poisson.py
+++ b/ngboost/distns/poisson.py
@@ -1,4 +1,5 @@
 """The NGBoost Poisson distribution and scores"""
+
 import numpy as np
 from scipy.optimize import Bounds, minimize
 from scipy.stats import poisson as dist

--- a/ngboost/distns/t.py
+++ b/ngboost/distns/t.py
@@ -1,4 +1,5 @@
 """The NGBoost Student T distribution and scores"""
+
 import numpy as np
 from scipy.special import digamma
 from scipy.stats import t as dist

--- a/ngboost/distns/utils.py
+++ b/ngboost/distns/utils.py
@@ -1,6 +1,7 @@
 """
     Extra functions useful for Distns
 """
+
 from ngboost.distns import RegressionDistn
 
 # pylint: disable=too-few-public-methods

--- a/ngboost/distns/weibull.py
+++ b/ngboost/distns/weibull.py
@@ -1,4 +1,5 @@
 """The NGBoost Weibull distribution and scores"""
+
 import numpy as np
 from scipy.stats import weibull_min as dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,28 +16,46 @@ license = "Apache License 2.0"
 python = ">=3.9, <3.14"
 scikit-learn = "^1.6"
 numpy = [
-    {version = ">=1.21.2", python = ">=3.9,<3.13"},
-    {version = ">=2.1.0", python = ">=3.13"}
+    {version = ">=1.21.2", markers = "python_version < '3.13'"},
+    {version = ">=2.1.0", markers = "python_version >= '3.13'"}
 ]
 scipy = [
-    {version = ">=1.7.2", python = ">=3.9,<3.13"},
-    {version = ">=1.14.1", python = ">=3.13"}
+    {version = ">=1.7.2", markers = "python_version < '3.13'"},
+    {version = ">=1.14.1", markers = "python_version >= '3.13'"}
 ]
 tqdm = ">=4.3"
 lifelines = ">=0.25"
 
-[tool.poetry.dev-dependencies]
-pytest = "^6.1.2"
-black = "^22.8.0"
-pre-commit = "^2.0"
-isort = "^5.6.4"
-pylint = "^3.0.3"
-flake8 = "^7.0.0"
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+black = "^24.0.0"
+pre-commit = "^4.0.0"
+isort = "^5.13.0"
+pylint = "^3.2.0"
+flake8 = "^7.1.0"
 
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.6dev"
+version = "0.5.7dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"

--- a/tests/test_distns.py
+++ b/tests/test_distns.py
@@ -35,6 +35,7 @@ from ngboost.scores import CRPScore, LogScore, Score
 Tuple4Array = Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 Tuple5Array = Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 
+
 # pylint: disable=redefined-outer-name
 @pytest.fixture(scope="module")
 def regression_data():


### PR DESCRIPTION
# Update dev dependencies and improve pyproject.toml configuration

## Overview
This PR updates all development dependencies to their latest versions and modernizes the project configuration to follow current best practices.

## Changes

### Dependency Updates
- **pytest**: `^6.1.2` → `^8.0.0`
- **black**: `^22.8.0` → `^24.0.0`
- **pre-commit**: `^2.0` → `^4.0.0`
- **isort**: `^5.6.4` → `^5.13.0`
- **pylint**: `^3.0.3` → `^3.2.0`
- **flake8**: `^7.0.0` → `^7.1.0`

### Configuration Improvements
- **Modern Poetry format**: Migrated from deprecated `[tool.poetry.dev-dependencies]` to `[tool.poetry.group.dev.dependencies]`
- **Black configuration**: Added explicit `[tool.black]` section with line length and target versions
- **Python version markers**: Improved numpy/scipy version constraints using PEP 508 markers for better clarity
- **Pre-commit updates**: 
  - Updated Black version in `.pre-commit-config.yaml` to match pyproject.toml
  - Fixed deprecated `default_stages` configuration
  - Updated pre-commit-hooks from v2.2.3 to v6.0.0

## Testing
- ✅ All tests pass locally
- ✅ All linters pass without warnings
- ✅ CI should pass cleanly (no more linting errors)

## Breaking Changes
None - this is purely a development dependency update with no impact on the public API.

## Related
Closes #379