### PR TITLE
Adding Hyvarinen Score Matching Score for the normal distribution

### DIFF
--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -72,6 +72,7 @@ class NormalScoreMatchingScore(ScoreMatchingScore):
         FI[:, 1, 1] = 4/(self.var)
         return FI
 
+
 class Normal(RegressionDistn):
     """
     Implements the normal distribution for NGBoost.

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -4,7 +4,7 @@ import scipy as sp
 from scipy.stats import norm as dist
 
 from ngboost.distns.distn import RegressionDistn
-from ngboost.scores import CRPScore, LogScore
+from ngboost.scores import CRPScore, LogScore, ScoreMatchingScore
 
 
 class NormalLogScore(LogScore):
@@ -51,6 +51,25 @@ class NormalCRPScore(CRPScore):
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
+class NormalScoreMatchingScore(ScoreMatchingScore):
+    def score(self, Y):
+        loc = self.loc
+        var = self.var
+        var = var
+        return ((Y - loc)**2 / (2* var**2)) - 1/var
+
+    def d_score(self, Y):
+        n = len(Y)
+        D = np.zeros((len(Y), 2))
+        D[:, 0] =  (self.loc -Y)/(self.var **2)
+        D[:, 1] = 2/self.var - (2*(Y - self.loc)**2)/(self.var**2)
+        return D
+
+    def metric(self):
+        FI = np.zeros((self.var.shape[0], 2, 2))
+        FI[:, 0, 0] = 1/(self.var**2)
+        FI[:, 1, 1] = 4/(self.var)
+        return FI
 
 class Normal(RegressionDistn):
     """
@@ -62,7 +81,7 @@ class Normal(RegressionDistn):
     """
 
     n_params = 2
-    scores = [NormalLogScore, NormalCRPScore]
+    scores = [NormalLogScore, NormalCRPScore, NormalScoreMatchingScore]
 
     def __init__(self, params):
         super().__init__(params)

--- a/ngboost/distns/normal.py
+++ b/ngboost/distns/normal.py
@@ -51,6 +51,7 @@ class NormalCRPScore(CRPScore):
         I = 1 / (2 * np.sqrt(np.pi)) * I
         return I
 
+
 class NormalScoreMatchingScore(ScoreMatchingScore):
     def score(self, Y):
         loc = self.loc

--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -39,3 +39,9 @@ class CRPScore(Score):
 
 
 CRPS = CRPScore
+
+class ScoreMatchingScore(Score):
+    """
+    Generic class for the Score Matching Score by Aapo Hyv{\"a}rinen
+    Reference http://www.jmlr.org/papers/v6/hyvarinen05a.html
+    """

--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -40,6 +40,7 @@ class CRPScore(Score):
 
 CRPS = CRPScore
 
+
 class ScoreMatchingScore(Score):
     """
     Generic class for the Score Matching Score by Aapo Hyv{\"a}rinen


### PR DESCRIPTION
In this pull request, I added the Hyvarinen Score Matching Score based on the paper http://jmlr.org/papers/v6/hyvarinen05a.html. The performance in terms of point estimation and negative log likelihood is very close to the logScore presented in the paper. 