### PR TITLE
Fix numpy2 natural gradient compatibility

### DIFF
--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -9,8 +9,41 @@ class Score:
         grad = self.d_score(Y)
         if natural:
             metric = self.metric()
-            grad = np.linalg.solve(metric, grad[..., None])[..., 0]
+            grad = self._natural_gradient(grad, metric)
         return grad
+    
+    def _natural_gradient(self, grad, metric):
+        """
+        Compute natural gradient with robust dimension handling.
+        
+        Args:
+            grad: Gradient array of shape (n_samples, n_params)
+            metric: Metric array of shape (n_samples, n_params, n_params)
+        
+        Returns:
+            Natural gradient array of shape (n_samples, n_params)
+        """
+        n_samples, n_params = grad.shape
+        
+        # Check if dimensions are compatible
+        if metric.shape != (n_samples, n_params, n_params):
+            raise ValueError(
+                f"Metric shape {metric.shape} is incompatible with gradient shape {grad.shape}. "
+                f"Expected metric shape: ({n_samples}, {n_params}, {n_params})"
+            )
+        
+        # Compute natural gradient for each sample
+        result = np.zeros_like(grad)
+        
+        for i in range(n_samples):
+            try:
+                # For each sample, solve: metric[i] * x = grad[i]
+                result[i] = np.linalg.solve(metric[i], grad[i])
+            except np.linalg.LinAlgError:
+                # Handle singular matrix case by using pseudo-inverse
+                result[i] = np.linalg.pinv(metric[i]) @ grad[i]
+        
+        return result
 
 
 class LogScore(Score):

--- a/ngboost/scores.py
+++ b/ngboost/scores.py
@@ -11,30 +11,30 @@ class Score:
             metric = self.metric()
             grad = self._natural_gradient(grad, metric)
         return grad
-    
+
     def _natural_gradient(self, grad, metric):
         """
         Compute natural gradient with robust dimension handling.
-        
+
         Args:
             grad: Gradient array of shape (n_samples, n_params)
             metric: Metric array of shape (n_samples, n_params, n_params)
-        
+
         Returns:
             Natural gradient array of shape (n_samples, n_params)
         """
         n_samples, n_params = grad.shape
-        
+
         # Check if dimensions are compatible
         if metric.shape != (n_samples, n_params, n_params):
             raise ValueError(
                 f"Metric shape {metric.shape} is incompatible with gradient shape {grad.shape}. "
                 f"Expected metric shape: ({n_samples}, {n_params}, {n_params})"
             )
-        
+
         # Compute natural gradient for each sample
         result = np.zeros_like(grad)
-        
+
         for i in range(n_samples):
             try:
                 # For each sample, solve: metric[i] * x = grad[i]
@@ -42,7 +42,7 @@ class Score:
             except np.linalg.LinAlgError:
                 # Handle singular matrix case by using pseudo-inverse
                 result[i] = np.linalg.pinv(metric[i]) @ grad[i]
-        
+
         return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.7"
+version = "0.5.7dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.7dev"
+version = "0.5.7"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"

--- a/tests/test_numpy2_compatibility.py
+++ b/tests/test_numpy2_compatibility.py
@@ -41,8 +41,10 @@ def test_natural_gradient_regression_numpy2_compatibility():
     """Test that natural gradients work with regression on NumPy 2.x"""
     print(f"NumPy version: {np.__version__}")
 
-    # Test regression
-    X, y, _ = make_regression(n_samples=100, n_features=5, noise=0.1, random_state=42)
+    # Test regression (unpack 2 values for broad sklearn compatibility)
+    X, y = make_regression(
+        n_samples=100, n_features=5, noise=0.1, random_state=42
+    )
 
     model = NGBRegressor(
         Dist=Normal, natural_gradient=True, n_estimators=10, verbose=False

--- a/tests/test_numpy2_compatibility.py
+++ b/tests/test_numpy2_compatibility.py
@@ -41,9 +41,9 @@ def test_natural_gradient_regression_numpy2_compatibility():
     """Test that natural gradients work with regression on NumPy 2.x"""
     print(f"NumPy version: {np.__version__}")
 
-    # Test regression (unpack 2 values for broad sklearn compatibility)
-    X, y = make_regression(
-        n_samples=100, n_features=5, noise=0.1, random_state=42
+    # Test regression (request coef to return 3-tuple and silence linter)
+    X, y, _ = make_regression(
+        n_samples=100, n_features=5, noise=0.1, random_state=42, coef=True
     )
 
     model = NGBRegressor(

--- a/tests/test_numpy2_compatibility.py
+++ b/tests/test_numpy2_compatibility.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Test for NumPy 2.x compatibility issues with natural gradients.
+
+This test reproduces the issue described in GitHub issue #384 and verifies the fix.
+"""
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_classification, make_regression
+from ngboost import NGBClassifier, NGBRegressor
+from ngboost.distns import Bernoulli, Normal
+from ngboost.manifold import manifold
+from ngboost.scores import LogScore
+
+
+def test_natural_gradient_numpy2_compatibility():
+    """Test that natural gradients work with NumPy 2.x"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Test classification
+    X, y = make_classification(n_samples=100, n_features=5, n_classes=2, random_state=42)
+    
+    model = NGBClassifier(Dist=Bernoulli, natural_gradient=True, 
+                         n_estimators=10, verbose=False)
+    
+    # This should not raise a dimension mismatch error
+    model.fit(X, y)
+    
+    # Test predictions
+    pred_dist = model.pred_dist(X[:5])
+    assert pred_dist is not None
+    print("✓ Classification with natural gradient works")
+
+
+def test_natural_gradient_regression_numpy2_compatibility():
+    """Test that natural gradients work with regression on NumPy 2.x"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Test regression
+    X, y = make_regression(n_samples=100, n_features=5, noise=0.1, random_state=42)
+    
+    model = NGBRegressor(Dist=Normal, natural_gradient=True, 
+                        n_estimators=10, verbose=False)
+    
+    # This should not raise a dimension mismatch error
+    model.fit(X, y)
+    
+    # Test predictions
+    pred_dist = model.pred_dist(X[:5])
+    assert pred_dist is not None
+    print("✓ Regression with natural gradient works")
+
+
+def test_natural_gradient_disabled_works():
+    """Test that disabling natural gradient works around any issues"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Test classification with natural gradient disabled
+    X, y = make_classification(n_samples=100, n_features=5, n_classes=2, random_state=42)
+    
+    model = NGBClassifier(Dist=Bernoulli, natural_gradient=False, 
+                         n_estimators=10, verbose=False)
+    
+    model.fit(X, y)
+    
+    # Test predictions
+    pred_dist = model.pred_dist(X[:5])
+    assert pred_dist is not None
+    print("✓ Classification with disabled natural gradient works")
+
+
+def test_gradient_computation_dimensions():
+    """Test that gradient computation handles dimensions correctly"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Create a test case
+    n_samples = 10
+    n_params = 2
+    
+    params = np.random.randn(n_params, n_samples)
+    Manifold = manifold(LogScore, Normal)
+    manifold_dist = Manifold(params)
+    y = np.random.randn(n_samples)
+    
+    # Test gradient computation
+    grad = manifold_dist.grad(y, natural=True)
+    
+    # Check dimensions
+    assert grad.shape == (n_samples, n_params)
+    print(f"✓ Gradient computation works: {grad.shape}")
+
+
+def test_dimension_mismatch_error_reproduction():
+    """Test that reproduces the dimension mismatch error for testing purposes"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Create a test case
+    n_samples = 5
+    n_params = 2
+    
+    params = np.random.randn(n_params, n_samples)
+    Manifold = manifold(LogScore, Normal)
+    manifold_dist = Manifold(params)
+    y = np.random.randn(n_samples)
+    
+    # Get d_score and metric
+    d_score_result = manifold_dist.d_score(y)
+    metric_result = manifold_dist.metric()
+    
+    # Test the current approach (should work)
+    try:
+        grad_expanded = d_score_result[..., None]
+        result = np.linalg.solve(metric_result, grad_expanded)
+        final_grad = result[..., 0]
+        print(f"✓ Current approach works: {final_grad.shape}")
+    except Exception as e:
+        print(f"✗ Current approach fails: {e}")
+        if "mismatch in its core dimension" in str(e):
+            print("*** FOUND THE DIMENSION MISMATCH ISSUE! ***")
+            pytest.fail("Dimension mismatch error found")
+    
+    # Test with incorrect dimensions (should fail gracefully)
+    try:
+        # Create incorrect gradient shape
+        wrong_grad = d_score_result.flatten()
+        result = np.linalg.solve(metric_result, wrong_grad[..., None])
+        print("✗ Unexpected: wrong dimensions worked")
+    except Exception as e:
+        print(f"✓ Expected failure with wrong dimensions: {e}")
+        if "mismatch in its core dimension" in str(e):
+            print("✓ Correctly caught dimension mismatch")
+
+
+def test_large_dataset_natural_gradient():
+    """Test natural gradient with larger datasets"""
+    print(f"NumPy version: {np.__version__}")
+    
+    # Test with larger dataset
+    X, y = make_classification(n_samples=500, n_features=10, n_classes=2, random_state=42)
+    
+    model = NGBClassifier(Dist=Bernoulli, natural_gradient=True, 
+                         n_estimators=5, verbose=False)
+    
+    # This should not raise a dimension mismatch error
+    model.fit(X, y)
+    
+    # Test predictions
+    pred_dist = model.pred_dist(X[:10])
+    assert pred_dist is not None
+    print("✓ Large dataset with natural gradient works")
+
+
+if __name__ == "__main__":
+    print("Testing NumPy 2.x compatibility...")
+    print("=" * 60)
+    
+    # Run all tests
+    test_natural_gradient_numpy2_compatibility()
+    test_natural_gradient_regression_numpy2_compatibility()
+    test_natural_gradient_disabled_works()
+    test_gradient_computation_dimensions()
+    test_dimension_mismatch_error_reproduction()
+    test_large_dataset_natural_gradient()
+    
+    print("\n" + "=" * 60)
+    print("All NumPy 2.x compatibility tests passed!")

--- a/tests/test_numpy2_compatibility.py
+++ b/tests/test_numpy2_compatibility.py
@@ -8,6 +8,7 @@ This test reproduces the issue described in GitHub issue #384 and verifies the f
 import numpy as np
 import pytest
 from sklearn.datasets import make_classification, make_regression
+
 from ngboost import NGBClassifier, NGBRegressor
 from ngboost.distns import Bernoulli, Normal
 from ngboost.manifold import manifold
@@ -17,16 +18,19 @@ from ngboost.scores import LogScore
 def test_natural_gradient_numpy2_compatibility():
     """Test that natural gradients work with NumPy 2.x"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Test classification
-    X, y = make_classification(n_samples=100, n_features=5, n_classes=2, random_state=42)
-    
-    model = NGBClassifier(Dist=Bernoulli, natural_gradient=True, 
-                         n_estimators=10, verbose=False)
-    
+    X, y = make_classification(
+        n_samples=100, n_features=5, n_classes=2, random_state=42
+    )
+
+    model = NGBClassifier(
+        Dist=Bernoulli, natural_gradient=True, n_estimators=10, verbose=False
+    )
+
     # This should not raise a dimension mismatch error
     model.fit(X, y)
-    
+
     # Test predictions
     pred_dist = model.pred_dist(X[:5])
     assert pred_dist is not None
@@ -36,16 +40,17 @@ def test_natural_gradient_numpy2_compatibility():
 def test_natural_gradient_regression_numpy2_compatibility():
     """Test that natural gradients work with regression on NumPy 2.x"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Test regression
-    X, y = make_regression(n_samples=100, n_features=5, noise=0.1, random_state=42)
-    
-    model = NGBRegressor(Dist=Normal, natural_gradient=True, 
-                        n_estimators=10, verbose=False)
-    
+    X, y, _ = make_regression(n_samples=100, n_features=5, noise=0.1, random_state=42)
+
+    model = NGBRegressor(
+        Dist=Normal, natural_gradient=True, n_estimators=10, verbose=False
+    )
+
     # This should not raise a dimension mismatch error
     model.fit(X, y)
-    
+
     # Test predictions
     pred_dist = model.pred_dist(X[:5])
     assert pred_dist is not None
@@ -55,15 +60,18 @@ def test_natural_gradient_regression_numpy2_compatibility():
 def test_natural_gradient_disabled_works():
     """Test that disabling natural gradient works around any issues"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Test classification with natural gradient disabled
-    X, y = make_classification(n_samples=100, n_features=5, n_classes=2, random_state=42)
-    
-    model = NGBClassifier(Dist=Bernoulli, natural_gradient=False, 
-                         n_estimators=10, verbose=False)
-    
+    X, y = make_classification(
+        n_samples=100, n_features=5, n_classes=2, random_state=42
+    )
+
+    model = NGBClassifier(
+        Dist=Bernoulli, natural_gradient=False, n_estimators=10, verbose=False
+    )
+
     model.fit(X, y)
-    
+
     # Test predictions
     pred_dist = model.pred_dist(X[:5])
     assert pred_dist is not None
@@ -73,19 +81,19 @@ def test_natural_gradient_disabled_works():
 def test_gradient_computation_dimensions():
     """Test that gradient computation handles dimensions correctly"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Create a test case
     n_samples = 10
     n_params = 2
-    
+
     params = np.random.randn(n_params, n_samples)
     Manifold = manifold(LogScore, Normal)
     manifold_dist = Manifold(params)
     y = np.random.randn(n_samples)
-    
+
     # Test gradient computation
     grad = manifold_dist.grad(y, natural=True)
-    
+
     # Check dimensions
     assert grad.shape == (n_samples, n_params)
     print(f"✓ Gradient computation works: {grad.shape}")
@@ -94,39 +102,39 @@ def test_gradient_computation_dimensions():
 def test_dimension_mismatch_error_reproduction():
     """Test that reproduces the dimension mismatch error for testing purposes"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Create a test case
     n_samples = 5
     n_params = 2
-    
+
     params = np.random.randn(n_params, n_samples)
     Manifold = manifold(LogScore, Normal)
     manifold_dist = Manifold(params)
     y = np.random.randn(n_samples)
-    
+
     # Get d_score and metric
     d_score_result = manifold_dist.d_score(y)
     metric_result = manifold_dist.metric()
-    
+
     # Test the current approach (should work)
     try:
         grad_expanded = d_score_result[..., None]
         result = np.linalg.solve(metric_result, grad_expanded)
         final_grad = result[..., 0]
         print(f"✓ Current approach works: {final_grad.shape}")
-    except Exception as e:
+    except (ValueError, np.linalg.LinAlgError) as e:
         print(f"✗ Current approach fails: {e}")
         if "mismatch in its core dimension" in str(e):
             print("*** FOUND THE DIMENSION MISMATCH ISSUE! ***")
             pytest.fail("Dimension mismatch error found")
-    
+
     # Test with incorrect dimensions (should fail gracefully)
     try:
         # Create incorrect gradient shape
         wrong_grad = d_score_result.flatten()
         result = np.linalg.solve(metric_result, wrong_grad[..., None])
         print("✗ Unexpected: wrong dimensions worked")
-    except Exception as e:
+    except (ValueError, np.linalg.LinAlgError) as e:
         print(f"✓ Expected failure with wrong dimensions: {e}")
         if "mismatch in its core dimension" in str(e):
             print("✓ Correctly caught dimension mismatch")
@@ -135,16 +143,19 @@ def test_dimension_mismatch_error_reproduction():
 def test_large_dataset_natural_gradient():
     """Test natural gradient with larger datasets"""
     print(f"NumPy version: {np.__version__}")
-    
+
     # Test with larger dataset
-    X, y = make_classification(n_samples=500, n_features=10, n_classes=2, random_state=42)
-    
-    model = NGBClassifier(Dist=Bernoulli, natural_gradient=True, 
-                         n_estimators=5, verbose=False)
-    
+    X, y = make_classification(
+        n_samples=500, n_features=10, n_classes=2, random_state=42
+    )
+
+    model = NGBClassifier(
+        Dist=Bernoulli, natural_gradient=True, n_estimators=5, verbose=False
+    )
+
     # This should not raise a dimension mismatch error
     model.fit(X, y)
-    
+
     # Test predictions
     pred_dist = model.pred_dist(X[:10])
     assert pred_dist is not None
@@ -154,7 +165,7 @@ def test_large_dataset_natural_gradient():
 if __name__ == "__main__":
     print("Testing NumPy 2.x compatibility...")
     print("=" * 60)
-    
+
     # Run all tests
     test_natural_gradient_numpy2_compatibility()
     test_natural_gradient_regression_numpy2_compatibility()
@@ -162,6 +173,6 @@ if __name__ == "__main__":
     test_gradient_computation_dimensions()
     test_dimension_mismatch_error_reproduction()
     test_large_dataset_natural_gradient()
-    
+
     print("\n" + "=" * 60)
     print("All NumPy 2.x compatibility tests passed!")


### PR DESCRIPTION
- Replace vectorized np.linalg.solve with sample-wise computation in scores.py
- Add robust dimension checking and error handling
- Handle singular matrix cases with pseudo-inverse fallback
- Add comprehensive test suite for NumPy 2.x compatibility
- Fixes GitHub issue #384: dimension mismatch in natural gradient computation

The original issue occurred when np.linalg.solve received incompatible
dimensions between metric and gradient arrays. The new implementation:
1. Validates dimensions before computation
2. Solves linear systems sample-by-sample for better stability
3. Provides clear error messages for dimension mismatches
4. Handles singular matrices gracefully

All existing tests pass and new compatibility tests verify the fix.

closes #399 