### PR TITLE
fix validation fraction api

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## Version 0.5.11
+
+* Fix `NGBClassifier` API parity by adding `validation_fraction` and `early_stopping_rounds`, with regression coverage for the validation-split path (issue #402)
+
 ## Version 0.5.10
 
 * Add `load_ngboost_model` compatibility loader for models saved with scikit-learn < 1.3 and loaded under newer scikit-learn versions (issue #389)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 ## Version 0.5.11
 
 * Fix `NGBClassifier` API parity by adding `validation_fraction` and `early_stopping_rounds`, with regression coverage for the validation-split path (issue #402)
+* Replace the deprecated `friedman_mse` criterion with `squared_error` for the default tree learner and distribution tests (issue #408, PR #409)
+* Support a distinct base learner for each distribution parameter, including scikit-learn nested parameters and feature importances for all-tree configurations (issue #338, PR #411)
 
 ## Version 0.5.10
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Version 0.5.11
 
-* Fix `NGBClassifier` API parity by adding `validation_fraction` and `early_stopping_rounds`, with regression coverage for the validation-split path (issue #402)
+* Fix `NGBClassifier` and `NGBSurvival` API parity by adding `validation_fraction` and `early_stopping_rounds`, with regression coverage for their validation-split paths (issue #402)
 * Replace the deprecated `friedman_mse` criterion with `squared_error` for the default tree learner and distribution tests (issue #408, PR #409)
 * Support a distinct base learner for each distribution parameter, including scikit-learn nested parameters and feature importances for all-tree configurations (issue #338, PR #411)
 

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -139,6 +139,12 @@ class NGBClassifier(NGBoost, BaseEstimator):
         tol               : numerical tolerance to be used in optimization
         random_state      : seed for reproducibility. See
                             https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
+        validation_fraction: Proportion of training data to set
+                             aside as validation data for early stopping.
+        early_stopping_rounds:      The number of consecutive boosting iterations during which the
+                                    loss has to increase before the algorithm stops early.
+                                    Set to None to disable early stopping and validation.
+                                    None enables running over the full data set.
     Output:
         An NGBClassifier object that can be fit.
     """
@@ -158,6 +164,8 @@ class NGBClassifier(NGBoost, BaseEstimator):
         verbose_eval=100,
         tol=1e-4,
         random_state=None,
+        validation_fraction=0.1,
+        early_stopping_rounds=None,
     ):
         assert issubclass(
             Dist, ClassificationDistn
@@ -175,6 +183,8 @@ class NGBClassifier(NGBoost, BaseEstimator):
             verbose_eval,
             tol,
             random_state,
+            validation_fraction,
+            early_stopping_rounds,
         )
         self._estimator_type = "classifier"
 

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -265,11 +265,17 @@ class NGBSurvival(NGBoost, BaseEstimator):
         tol               : numerical tolerance to be used in optimization
         random_state      : seed for reproducibility. See
                             https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
+        validation_fraction: Proportion of training data to set
+                             aside as validation data for early stopping.
+        early_stopping_rounds:      The number of consecutive boosting iterations during which the
+                                    loss has to increase before the algorithm stops early.
+                                    Set to None to disable early stopping and validation.
+                                    None enables running over the full data set.
     Output:
         An NGBSurvival object that can be fit.
     """
 
-    # pylint: disable=too-many-positional-arguments
+    # pylint: disable=too-many-positional-arguments,too-many-locals
     def __init__(
         self,
         Dist=LogNormal,
@@ -284,6 +290,8 @@ class NGBSurvival(NGBoost, BaseEstimator):
         verbose_eval=100,
         tol=1e-4,
         random_state=None,
+        validation_fraction=0.1,
+        early_stopping_rounds=None,
     ):
 
         assert issubclass(
@@ -310,6 +318,8 @@ class NGBSurvival(NGBoost, BaseEstimator):
             verbose_eval,
             tol,
             random_state,
+            validation_fraction,
+            early_stopping_rounds,
         )
 
     def __getstate__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ngboost"
-version = "0.5.10dev"
+version = "0.5.11dev"
 description = "Library for probabilistic predictions via gradient boosting."
 authors = ["Stanford ML Group <avati@cs.stanford.edu>"]
 readme = "README.md"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -54,3 +54,22 @@ def test_regression(california_housing_data):
 
     score = mean_squared_error(y_test, preds)
     assert score <= 15
+
+
+def test_classifier_validation_fraction_is_supported(breast_cancer_data):
+    x_train, x_test, y_train, _ = breast_cancer_data
+    ngb = NGBClassifier(
+        Dist=Bernoulli,
+        n_estimators=25,
+        verbose=False,
+        random_state=1,
+        validation_fraction=0.2,
+        early_stopping_rounds=2,
+    )
+
+    assert ngb.get_params()["validation_fraction"] == 0.2
+    assert ngb.get_params()["early_stopping_rounds"] == 2
+
+    ngb.fit(x_train, y_train)
+    preds = ngb.predict(x_test)
+    assert preds.shape[0] == x_test.shape[0]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,7 +5,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import Ridge
 from sklearn.tree import DecisionTreeRegressor
 
-from ngboost import NGBClassifier, NGBRegressor
+from ngboost import NGBClassifier, NGBRegressor, NGBSurvival
 from ngboost.distns import Bernoulli, Normal, k_categorical
 
 
@@ -89,6 +89,26 @@ def test_classifier_validation_fraction_is_supported(breast_cancer_data):
     assert ngb.get_params()["early_stopping_rounds"] == 2
 
     ngb.fit(x_train, y_train)
+    preds = ngb.predict(x_test)
+    assert preds.shape[0] == x_test.shape[0]
+
+
+def test_survival_validation_fraction_is_supported(
+    california_housing_survival_data,
+):
+    x_train, x_test, t_train, e_train, _ = california_housing_survival_data
+    ngb = NGBSurvival(
+        n_estimators=5,
+        verbose=False,
+        random_state=1,
+        validation_fraction=0.2,
+        early_stopping_rounds=2,
+    )
+
+    assert ngb.get_params()["validation_fraction"] == 0.2
+    assert ngb.get_params()["early_stopping_rounds"] == 2
+
+    ngb.fit(x_train, t_train, e_train)
     preds = ngb.predict(x_test)
     assert preds.shape[0] == x_test.shape[0]
 


### PR DESCRIPTION
Implemented issue to close #402 by fixing API parity for validation-based early stopping in classification.

What changed
Added validation_fraction and early_stopping_rounds to `NGBClassifier.__init__` and forwarded both to NGBoost.
Added regression test `test_classifier_validation_fraction_is_supported` to ensure classifier accepts these params, exposes them via `get_params()`, and trains/predicts with validation-split early stopping enabled.