### PR TITLE
support parameter-specific base learners

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -1,4 +1,5 @@
 "The NGBoost library API"
+
 # pylint: disable=too-many-arguments
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_array
@@ -31,8 +32,10 @@ class NGBRegressor(NGBoost, BaseEstimator):
                             A distribution from ngboost.distns, e.g. Normal
         Score             : rule to compare probabilistic predictions P̂ to the observed data y.
                             A score from ngboost.scores, e.g. LogScore
-        Base              : base learner to use in the boosting algorithm.
-                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()
+        Base              : base learner(s) to use in the boosting algorithm.
+                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor(),
+                            or a list/tuple of instantiated sklearn regressors with length
+                            equal to Dist.n_params.
         natural_gradient  : logical flag indicating whether the natural gradient should be used
         n_estimators      : the number of boosting iterations to fit
         learning_rate     : the learning rate
@@ -127,8 +130,10 @@ class NGBClassifier(NGBoost, BaseEstimator):
                             A distribution from ngboost.distns, e.g. Bernoulli
         Score             : rule to compare probabilistic predictions P̂ to the observed data y.
                             A score from ngboost.scores, e.g. LogScore
-        Base              : base learner to use in the boosting algorithm.
-                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()
+        Base              : base learner(s) to use in the boosting algorithm.
+                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor(),
+                            or a list/tuple of instantiated sklearn regressors with length
+                            equal to Dist.n_params.
         natural_gradient  : logical flag indicating whether the natural gradient should be used
         n_estimators      : the number of boosting iterations to fit
         learning_rate     : the learning rate
@@ -221,8 +226,10 @@ class NGBSurvival(NGBoost, BaseEstimator):
                             A distribution from ngboost.distns, e.g. LogNormal
         Score             : rule to compare probabilistic predictions P̂ to the observed data y.
                             A score from ngboost.scores, e.g. LogScore
-        Base              : base learner to use in the boosting algorithm.
-                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()
+        Base              : base learner(s) to use in the boosting algorithm.
+                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor(),
+                            or a list/tuple of instantiated sklearn regressors with length
+                            equal to Dist.n_params.
         natural_gradient  : logical flag indicating whether the natural gradient should be used
         n_estimators      : the number of boosting iterations to fit
         learning_rate     : the learning rate

--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -29,8 +29,10 @@ class NGBoost:
                             A distribution from ngboost.distns, e.g. Normal
         Score             : rule to compare probabilistic predictions P̂ to the observed data y.
                             A score from ngboost.scores, e.g. LogScore
-        Base              : base learner to use in the boosting algorithm.
-                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor()
+        Base              : base learner(s) to use in the boosting algorithm.
+                            Any instantiated sklearn regressor, e.g. DecisionTreeRegressor(),
+                            or a list/tuple of instantiated sklearn regressors with length
+                            equal to Dist.n_params.
         natural_gradient  : logical flag indicating whether the natural gradient should be used
         n_estimators      : the number of boosting iterations to fit
         learning_rate     : the learning rate
@@ -167,12 +169,25 @@ class NGBoost:
             params[idxs, :],
         )
 
+    def _base_learners(self):
+        if not isinstance(self.Base, (list, tuple)):
+            return [self.Base] * self.Manifold.n_params
+
+        if len(self.Base) != self.Manifold.n_params:
+            raise ValueError(
+                "Base must be a single estimator or a sequence of "
+                f"{self.Manifold.n_params} estimators, got {len(self.Base)}."
+            )
+        return self.Base
+
     def fit_base(self, X, grads, sample_weight=None):
+        base_learners = self._base_learners()
         if sample_weight is None:
-            models = [clone(self.Base).fit(X, g) for g in grads.T]
+            models = [clone(base).fit(X, g) for base, g in zip(base_learners, grads.T)]
         else:
             models = [
-                clone(self.Base).fit(X, g, sample_weight=sample_weight) for g in grads.T
+                clone(base).fit(X, g, sample_weight=sample_weight)
+                for base, g in zip(base_learners, grads.T)
             ]
         fitted = np.array([m.predict(X) for m in models]).T
         self.base_models.append(models)
@@ -616,8 +631,12 @@ class NGBoost:
         # Check whether the model is fitted
         if not self.base_models:
             return None
-        # Check whether the base model is DecisionTreeRegressor
-        if not isinstance(self.base_models[0][0], DecisionTreeRegressor):
+        # Check whether all base models are DecisionTreeRegressor
+        if any(
+            not isinstance(model, DecisionTreeRegressor)
+            for models in self.base_models
+            for model in models
+        ):
             return None
         # Reshape the base_models
         params_trees = zip(*self.base_models)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,10 @@
+import numpy as np
+import pytest
+from sklearn.linear_model import Ridge
+from sklearn.tree import DecisionTreeRegressor
+
 from ngboost import NGBClassifier, NGBRegressor
-from ngboost.distns import Bernoulli, Normal
+from ngboost.distns import Bernoulli, Normal, k_categorical
 
 
 # TODO: This is non-deterministic in the model fitting
@@ -54,3 +59,110 @@ def test_regression(california_housing_data):
 
     score = mean_squared_error(y_test, preds)
     assert score <= 15
+
+
+def test_regression_accepts_base_learner_per_distribution_parameter():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(80, 4))
+    Y = X[:, 0] - 0.5 * X[:, 1] + rng.normal(scale=0.1, size=80)
+
+    ngb = NGBRegressor(
+        Dist=Normal,
+        Base=[DecisionTreeRegressor(max_depth=1), Ridge(alpha=0.0)],
+        n_estimators=2,
+        natural_gradient=False,
+        verbose=False,
+    )
+
+    ngb.fit(X, Y)
+
+    assert len(ngb.base_models) == 2
+    for models in ngb.base_models:
+        assert len(models) == Normal.n_params
+        assert isinstance(models[0], DecisionTreeRegressor)
+        assert isinstance(models[1], Ridge)
+
+    preds = ngb.predict(X[:5])
+    dist = ngb.pred_dist(X[:5])
+
+    assert preds.shape == (5,)
+    assert isinstance(dist, Normal)
+
+
+def test_classification_accepts_base_learner_per_distribution_parameter():
+    rng = np.random.default_rng(4)
+    X = rng.normal(size=(90, 3))
+    Y = np.argmax(np.column_stack([X[:, 0], X[:, 1], -X[:, 0] - X[:, 1]]), axis=1)
+
+    ngb = NGBClassifier(
+        Dist=k_categorical(3),
+        Base=[DecisionTreeRegressor(max_depth=1), DecisionTreeRegressor(max_depth=2)],
+        n_estimators=2,
+        natural_gradient=False,
+        verbose=False,
+    )
+
+    ngb.fit(X, Y)
+
+    for models in ngb.base_models:
+        assert len(models) == 2
+        assert models[0].max_depth == 1
+        assert models[1].max_depth == 2
+
+    assert ngb.predict_proba(X[:5]).shape == (5, 3)
+
+
+def test_base_learner_sequence_must_match_distribution_parameter_count():
+    rng = np.random.default_rng(1)
+    X = rng.normal(size=(20, 2))
+    Y = rng.normal(size=20)
+
+    ngb = NGBRegressor(
+        Dist=Normal,
+        Base=[DecisionTreeRegressor(max_depth=1)],
+        n_estimators=1,
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError, match="sequence of 2 estimators"):
+        ngb.fit(X, Y)
+
+
+def test_single_base_learner_matches_repeated_base_learner_sequence():
+    rng = np.random.default_rng(2)
+    X = rng.normal(size=(60, 3))
+    Y = X[:, 0] + rng.normal(scale=0.1, size=60)
+    base = DecisionTreeRegressor(max_depth=2, random_state=0)
+
+    single_base = NGBRegressor(
+        Dist=Normal,
+        Base=base,
+        n_estimators=3,
+        natural_gradient=False,
+        verbose=False,
+    ).fit(X, Y)
+    repeated_base = NGBRegressor(
+        Dist=Normal,
+        Base=[base, base],
+        n_estimators=3,
+        natural_gradient=False,
+        verbose=False,
+    ).fit(X, Y)
+
+    np.testing.assert_allclose(single_base.pred_param(X), repeated_base.pred_param(X))
+
+
+def test_feature_importances_are_none_for_mixed_base_learners():
+    rng = np.random.default_rng(3)
+    X = rng.normal(size=(40, 3))
+    Y = X[:, 0] + rng.normal(scale=0.1, size=40)
+
+    ngb = NGBRegressor(
+        Dist=Normal,
+        Base=[DecisionTreeRegressor(max_depth=1), Ridge(alpha=0.0)],
+        n_estimators=1,
+        natural_gradient=False,
+        verbose=False,
+    ).fit(X, Y)
+
+    assert ngb.feature_importances_ is None


### PR DESCRIPTION
## summary

adds support for passing one base learner per distribution parameter.

`Base` can now be either:

- a single sklearn regressor, preserving the existing behavior
- a list/tuple of sklearn regressors with length equal to `Dist.n_params`

this lets users fit different learners for different distribution parameters, for example using a constrained learner for the location parameter and a different learner for the scale parameter.

closes #338.

## implementation

the existing internal structure already stores one fitted model per distribution parameter at each boosting iteration. this change updates `fit_base()` so it clones the corresponding base learner for each parameter instead of cloning the same `self.Base` for every parameter.

it also makes `feature_importances_` return `None` when any fitted parameter model is not a `DecisionTreeRegressor`, which avoids errors for mixed learner setups.

## tests

added coverage for:

- `NGBRegressor` with different learners for `Normal` parameters
- `NGBClassifier` with different learners for `k_categorical(3)` parameters
- invalid base learner sequence length
- backward compatibility between a single base learner and an equivalent repeated sequence
- mixed learners with `feature_importances_`

tested with:

```sh
.venv/bin/python -m black --check ngboost/ngboost.py ngboost/api.py tests/test_basic.py
git diff --check
.venv/bin/python -m pytest -q
```

result:

```text
58 passed, 57 skipped
```
