### PR TITLE
set classifier metadata

### DIFF
--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -1,7 +1,8 @@
 "The NGBoost library API"
 
 # pylint: disable=too-many-arguments
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
 
 from ngboost.distns import (
@@ -122,7 +123,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
         super().__setstate__(state_dict)
 
 
-class NGBClassifier(NGBoost, BaseEstimator):
+class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
     """
     Constructor for NGBoost classification models.
 
@@ -154,6 +155,12 @@ class NGBClassifier(NGBoost, BaseEstimator):
         tol               : numerical tolerance to be used in optimization
         random_state      : seed for reproducibility. See
                             https://stackoverflow.com/questions/28064634/random-state-pseudo-random-number-in-scikit-learn
+        validation_fraction: Proportion of training data to set
+                             aside as validation data for early stopping.
+        early_stopping_rounds:      The number of consecutive boosting iterations during which the
+                                    loss has to increase before the algorithm stops early.
+                                    Set to None to disable early stopping and validation.
+                                    None enables running over the full data set.
     Output:
         An NGBClassifier object that can be fit.
     """
@@ -173,6 +180,8 @@ class NGBClassifier(NGBoost, BaseEstimator):
         verbose_eval=100,
         tol=1e-4,
         random_state=None,
+        validation_fraction=0.1,
+        early_stopping_rounds=None,
     ):
         assert issubclass(
             Dist, ClassificationDistn
@@ -190,8 +199,92 @@ class NGBClassifier(NGBoost, BaseEstimator):
             verbose_eval,
             tol,
             random_state,
+            validation_fraction,
+            early_stopping_rounds,
         )
         self._estimator_type = "classifier"
+
+    def _encode_labels(self, Y):
+        return self._le.transform(Y)
+
+    # pylint: disable=too-many-positional-arguments,attribute-defined-outside-init
+    def fit(
+        self,
+        X,
+        Y,
+        X_val=None,
+        Y_val=None,
+        sample_weight=None,
+        val_sample_weight=None,
+        train_loss_monitor=None,
+        val_loss_monitor=None,
+        early_stopping_rounds=None,
+    ):
+        self._le = LabelEncoder().fit(Y)
+        self.classes_ = self._le.classes_
+        Y = self._encode_labels(Y)
+        if Y_val is not None:
+            Y_val = self._le.transform(Y_val)
+        self.base_models = []
+        self.scalings = []
+        self.col_idxs = []
+        return NGBoost.partial_fit(
+            self,
+            X,
+            Y,
+            X_val=X_val,
+            Y_val=Y_val,
+            sample_weight=sample_weight,
+            val_sample_weight=val_sample_weight,
+            train_loss_monitor=train_loss_monitor,
+            val_loss_monitor=val_loss_monitor,
+            early_stopping_rounds=early_stopping_rounds,
+        )
+
+    # pylint: disable=too-many-positional-arguments,attribute-defined-outside-init
+    def partial_fit(
+        self,
+        X,
+        Y,
+        X_val=None,
+        Y_val=None,
+        sample_weight=None,
+        val_sample_weight=None,
+        train_loss_monitor=None,
+        val_loss_monitor=None,
+        early_stopping_rounds=None,
+    ):
+        if not hasattr(self, "classes_"):
+            self._le = LabelEncoder().fit(Y)
+            self.classes_ = self._le.classes_
+        Y = self._encode_labels(Y)
+        if Y_val is not None:
+            Y_val = self._le.transform(Y_val)
+        return NGBoost.partial_fit(
+            self,
+            X,
+            Y,
+            X_val=X_val,
+            Y_val=Y_val,
+            sample_weight=sample_weight,
+            val_sample_weight=val_sample_weight,
+            train_loss_monitor=train_loss_monitor,
+            val_loss_monitor=val_loss_monitor,
+            early_stopping_rounds=early_stopping_rounds,
+        )
+
+    def predict(self, X, max_iter=None):
+        return self.classes_[super().predict(X, max_iter=max_iter)]
+
+    def staged_predict(self, X, max_iter=None):
+        return [
+            self.classes_[pred] for pred in super().staged_predict(X, max_iter=max_iter)
+        ]
+
+    def score(self, X, Y):  # for sklearn
+        return self.Manifold(self.pred_param(check_array(X)).T).total_score(
+            self._le.transform(Y)
+        )
 
     def predict_proba(self, X, max_iter=None):
         """

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -123,6 +123,7 @@ class NGBRegressor(NGBoost, BaseEstimator):
         super().__setstate__(state_dict)
 
 
+# pylint: disable=duplicate-code
 class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
     """
     Constructor for NGBoost classification models.

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -207,8 +207,9 @@ class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
         self._estimator_type = "classifier"
 
     def _fit_label_encoder(self, Y):
-        self._le = LabelEncoder().fit(Y)
-        self.classes_ = self._le.classes_
+        le = LabelEncoder().fit(Y)
+        self._le = le  # pylint: disable=attribute-defined-outside-init
+        self.classes_ = le.classes_  # pylint: disable=attribute-defined-outside-init
         n_classes = self.Dist.n_params + 1
         if len(self.classes_) != n_classes:
             raise ValueError(
@@ -219,7 +220,9 @@ class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
     def _encode_labels(self, Y):
         return self._le.transform(Y)
 
-    def __setstate__(self, state_dict):
+    def __setstate__(
+        self, state_dict
+    ):  # pylint: disable=attribute-defined-outside-init
         super().__setstate__(state_dict)
         if not hasattr(self, "classes_"):
             self.classes_ = np.arange(self.Dist.n_params + 1)

--- a/ngboost/api.py
+++ b/ngboost/api.py
@@ -1,6 +1,7 @@
 "The NGBoost library API"
 
 # pylint: disable=too-many-arguments
+import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
@@ -205,8 +206,26 @@ class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
         )
         self._estimator_type = "classifier"
 
+    def _fit_label_encoder(self, Y):
+        self._le = LabelEncoder().fit(Y)
+        self.classes_ = self._le.classes_
+        n_classes = self.Dist.n_params + 1
+        if len(self.classes_) != n_classes:
+            raise ValueError(
+                "NGBClassifier Dist expects "
+                f"{n_classes} classes, got {len(self.classes_)}."
+            )
+
     def _encode_labels(self, Y):
         return self._le.transform(Y)
+
+    def __setstate__(self, state_dict):
+        super().__setstate__(state_dict)
+        if not hasattr(self, "classes_"):
+            self.classes_ = np.arange(self.Dist.n_params + 1)
+        if not hasattr(self, "_le"):
+            self._le = LabelEncoder()
+            self._le.classes_ = self.classes_
 
     # pylint: disable=too-many-positional-arguments,attribute-defined-outside-init
     def fit(
@@ -221,8 +240,7 @@ class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
         val_loss_monitor=None,
         early_stopping_rounds=None,
     ):
-        self._le = LabelEncoder().fit(Y)
-        self.classes_ = self._le.classes_
+        self._fit_label_encoder(Y)
         Y = self._encode_labels(Y)
         if Y_val is not None:
             Y_val = self._le.transform(Y_val)
@@ -256,8 +274,7 @@ class NGBClassifier(ClassifierMixin, NGBoost, BaseEstimator):
         early_stopping_rounds=None,
     ):
         if not hasattr(self, "classes_"):
-            self._le = LabelEncoder().fit(Y)
-            self.classes_ = self._le.classes_
+            self._fit_label_encoder(Y)
         Y = self._encode_labels(Y)
         if Y_val is not None:
             Y_val = self._le.transform(Y_val)

--- a/ngboost/helpers.py
+++ b/ngboost/helpers.py
@@ -14,6 +14,7 @@ from sklearn.utils import check_array
 _TREE_MODULE_SWAP_LOCK = threading.RLock()
 
 
+# pylint: disable-next=c-extension-no-member
 class _CompatTree(_sklearn_tree.Tree):  # pylint: disable=too-few-public-methods
     """Transient subclass of sklearn's Tree used only during loading.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -20,6 +20,48 @@ class RecordingRegressor(BaseEstimator, RegressorMixin):
         return np.full(X.shape[0], self.prediction_)
 
 
+def test_classifier_sets_sklearn_classes_and_encodes_labels(breast_cancer_data):
+    from sklearn.base import is_classifier  # pylint: disable=import-outside-toplevel
+    from sklearn.metrics import (  # pylint: disable=import-outside-toplevel
+        RocCurveDisplay,
+    )
+    from sklearn.model_selection import (  # pylint: disable=import-outside-toplevel
+        cross_val_score,
+    )
+
+    x_train, x_test, y_train, y_test = breast_cancer_data
+    y_labels = ["malignant" if y == 0 else "benign" for y in y_train]
+    y_test_labels = ["malignant" if y == 0 else "benign" for y in y_test]
+
+    ngb = NGBClassifier(
+        Dist=Bernoulli,
+        n_estimators=2,
+        verbose=False,
+        random_state=0,
+    )
+
+    assert is_classifier(ngb)
+    assert isinstance(clone(ngb), NGBClassifier)
+
+    ngb.fit(x_train, y_labels)
+
+    assert list(ngb.classes_) == ["benign", "malignant"]
+    assert set(ngb.predict(x_test[:10])).issubset(set(ngb.classes_))
+    assert ngb.predict_proba(x_test[:10]).shape == (10, 2)
+    assert len(ngb.staged_predict(x_test[:10])) == len(ngb.base_models)
+    assert cross_val_score(ngb, x_train, y_labels, scoring="roc_auc", cv=3).shape == (
+        3,
+    )
+
+    display = RocCurveDisplay.from_estimator(
+        ngb,
+        x_test,
+        y_test_labels,
+        pos_label="malignant",
+    )
+    assert display.roc_auc >= 0.5
+
+
 # TODO: This is non-deterministic in the model fitting
 def test_classification(breast_cancer_data):
     from sklearn.metrics import (  # pylint: disable=import-outside-toplevel

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -62,6 +62,14 @@ def test_classifier_sets_sklearn_classes_and_encodes_labels(breast_cancer_data):
     assert display.roc_auc >= 0.5
 
 
+def test_classifier_rejects_label_count_mismatch(breast_cancer_data):
+    x_train, _, y_train, _ = breast_cancer_data
+    ngb = NGBClassifier(Dist=k_categorical(3), n_estimators=2, verbose=False)
+
+    with pytest.raises(ValueError, match="expects 3 classes, got 2"):
+        ngb.fit(x_train, y_train)
+
+
 # TODO: This is non-deterministic in the model fitting
 def test_classification(breast_cancer_data):
     from sklearn.metrics import (  # pylint: disable=import-outside-toplevel

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,7 +34,9 @@ def _make_old_style_pickle_bytes(model):
 
     buf = io.BytesIO()
     pickler = pickle.Pickler(buf)
-    pickler.dispatch_table = {_sklearn_tree.Tree: _old_tree_reducer}
+    pickler.dispatch_table = {
+        _sklearn_tree.Tree: _old_tree_reducer  # pylint: disable=c-extension-no-member
+    }
     pickler.dump(model)
     return buf.getvalue()
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -74,7 +74,8 @@ def test_classifier_setstate_restores_missing_label_metadata(breast_cancer_data)
     model.__setstate__(state)
 
     assert np.array_equal(model.classes_, np.array([0, 1]))
-    assert np.array_equal(model._le.classes_, model.classes_)  # pylint: disable=protected-access
+    label_classes = model._le.classes_  # pylint: disable=protected-access
+    assert np.array_equal(label_classes, model.classes_)
     assert np.array_equal(model.predict(X_train[:5]), ngb.predict(X_train[:5]))
     assert np.allclose(model.predict_proba(X_train[:5]), ngb.predict_proba(X_train[:5]))
 
@@ -115,8 +116,8 @@ def _make_old_style_pickle_bytes(model):
 
     buf = io.BytesIO()
     p = pickle.Pickler(buf)
-    p.dispatch_table = {  # pylint: disable=c-extension-no-member
-        _sklearn_tree.Tree: _old_tree_reducer
+    p.dispatch_table = {
+        _sklearn_tree.Tree: _old_tree_reducer  # pylint: disable=c-extension-no-member
     }
     p.dump(model)
     return buf.getvalue()
@@ -172,8 +173,9 @@ def test_backward_compat_load(learners_data):
             assert (new_preds == preds).all()
             for iter_models in model.base_models:
                 for estimator in iter_models:
-                    assert isinstance(  # pylint: disable=c-extension-no-member
-                        estimator.tree_, _sklearn_tree.Tree
-                    )
+                    tree_type = (
+                        _sklearn_tree.Tree
+                    )  # pylint: disable=c-extension-no-member
+                    assert isinstance(estimator.tree_, tree_type)
         finally:
             os.unlink(tmp_path)

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -59,6 +59,26 @@ def test_model_save(learners_data):
         assert (new_preds == preds).all()
 
 
+def test_classifier_setstate_restores_missing_label_metadata(breast_cancer_data):
+    """Older classifier pickles do not include the sklearn label metadata."""
+
+    X_train, _, Y_train, _ = breast_cancer_data
+    ngb = NGBClassifier(verbose=False, n_estimators=2)
+    ngb.fit(X_train, Y_train)
+
+    state = ngb.__getstate__()
+    state.pop("classes_", None)
+    state.pop("_le", None)
+
+    model = NGBClassifier()
+    model.__setstate__(state)
+
+    assert np.array_equal(model.classes_, np.array([0, 1]))
+    assert np.array_equal(model._le.classes_, model.classes_)  # pylint: disable=protected-access
+    assert np.array_equal(model.predict(X_train[:5]), ngb.predict(X_train[:5]))
+    assert np.allclose(model.predict_proba(X_train[:5]), ngb.predict_proba(X_train[:5]))
+
+
 # ---------------------------------------------------------------------------
 # Helpers for backward-compatibility test (issue #389)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## summary

sets the sklearn classifier metadata that `NGBClassifier` was missing, so sklearn tooling can treat it as a classifier after fitting.

fixes #350.

## what changed

- make `NGBClassifier` inherit from `ClassifierMixin`
- set `classes_` during `fit` and first `partial_fit`
- encode labels internally with `LabelEncoder`
- decode `predict` and `staged_predict` back to the original labels
- encode `Y_val` when validation data is passed
- keep `predict_proba` aligned with `classes_`
- add classifier regression coverage for sklearn compatibility

## why

sklearn metrics/display helpers such as `RocCurveDisplay.from_estimator` and `cross_val_score(..., scoring="roc_auc")` expect fitted classifiers to expose classifier metadata, especially `classes_`.

without it, `NGBClassifier` can fit and predict, but fails in common sklearn evaluation paths.

## validation

- `git diff --check`
- `make lint`
- manual sklearn probe for issue #350, string labels, validation labels, `partial_fit`, multiclass labels, clone, and pickle round-trip
- `pytest tests/test_basic.py::test_classifier_sets_sklearn_classes_and_encodes_labels -q`
- `pytest tests/test_basic.py -q`
- `pytest -q`
- `make test`
