### PR TITLE
use wheel-backed scikit-learn on python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.15"
-scikit-learn = "^1.6"
+scikit-learn = [
+    {version = ">=1.6,<1.7", markers = "python_version < '3.14'"},
+    {version = ">=1.8.0,<2.0", markers = "python_version >= '3.14'"}
+]
 numpy = [
     {version = ">=1.21.2", markers = "python_version < '3.13'"},
     {version = ">=2.1.0", markers = "python_version >= '3.13'"}


### PR DESCRIPTION
summary
- route Python 3.14 installs to a scikit-learn range with native cp314 wheels
- keep Python <3.14 on the 1.6 series that current CI already resolves
- avoids the source build that made the Python 3.14 CI job several minutes slower

why
- issue #412 tracks the Python 3.14 CI job taking roughly 6 minutes longer than the other supported Python versions
- recent CI runs show the delta is in the install step, not the test step:
  - run 28058718072: py3.14 install 263s vs py3.9-py3.13 installs 48-57s
  - run 28057448161: py3.14 install 256s vs py3.9-py3.13 installs 44-57s
  - run 28001330616: py3.14 install 266s vs py3.9-py3.13 installs 40-58s
- the Python 3.14 job resolved scikit-learn 1.6.1, which has no cp314 Linux wheel, so CI builds it from source
- scikit-learn 1.8.0+ publishes cp314 wheels, so Python 3.14 can install from wheels like the rest of the matrix

validation
- `git diff --check`
- `poetry check`
- verified no overlapping open PR for #412 / Python 3.14 runtime / scikit-learn
- marker sanity check: Python 3.9-3.13 select `>=1.6,<1.7`; Python 3.14 selects `>=1.8.0,<2.0`
- `pip download --only-binary=:all: --python-version 314 --implementation cp --abi cp314 --platform manylinux_2_28_x86_64 --no-deps 'scikit-learn==1.6.1'` fails with no matching binary
- `pip download --only-binary=:all: --python-version 314 --implementation cp --abi cp314 --platform manylinux_2_28_x86_64 --no-deps 'scikit-learn>=1.8.0,<2.0'` resolves/downloads scikit-learn 1.9.0 cp314 manylinux wheel
- fresh Poetry 2.0.1 install on Python 3.11 resolves scikit-learn 1.6.1
- fresh Poetry 2.0.1 install on Python 3.14 resolves scikit-learn 1.9.0
- fresh clean clone from current upstream with only this diff applied:
  - `make install` on Python 3.14 installed scikit-learn 1.9.0
  - `make lint` passed
  - `make test` passed (`86 passed, 2 xfailed, 22 xpassed`)

closes #412
